### PR TITLE
Persisted Operations reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 armor.yml
 operations.json
 TODO.md
+main

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,7 +64,11 @@ func run(ctx context.Context, log *slog.Logger, cfg *config.Config, shutdown cha
 		log.Error("Unable to determine loading strategy for persisted operations", "err", err)
 	}
 
-	po, _ := persisted_operations.NewPersistedOperations(log, cfg.PersistedOperations, persisted_operations.NewLocalDirLoader(cfg.PersistedOperations), poLoader)
+	po, err := persisted_operations.NewPersistedOperations(log, cfg.PersistedOperations, persisted_operations.NewLocalDirLoader(cfg.PersistedOperations), poLoader)
+	if err != nil {
+		log.Error("Error creating Persisted Operations", "err", err)
+		return nil
+	}
 
 	mux := http.NewServeMux()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func run(ctx context.Context, log *slog.Logger, cfg *config.Config, shutdown cha
 
 	mux := http.NewServeMux()
 
-	mid := middleware(log, cfg, po)
+	mid := middleware(log, po)
 	mux.Handle(cfg.Web.Path, mid(Handler(pxy)))
 
 	api := http.Server{
@@ -113,7 +113,7 @@ func run(ctx context.Context, log *slog.Logger, cfg *config.Config, shutdown cha
 	return nil
 }
 
-func middleware(log *slog.Logger, cfg *config.Config, po *persisted_operations.PersistedOperationsHandler) func(next http.Handler) http.Handler {
+func middleware(log *slog.Logger, po *persisted_operations.PersistedOperationsHandler) func(next http.Handler) http.Handler {
 	rec := middleware2.Recover(log)
 
 	fn := func(next http.Handler) http.Handler {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/ardanlabs/conf/v3"
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
@@ -58,13 +59,13 @@ func run(log *slog.Logger, cfg *config.Config, shutdown chan os.Signal) error {
 	}
 
 	remoteLoader, err := persisted_operations.RemoteLoaderFromConfig(cfg.PersistedOperations)
-	if err != nil {
+	if err != nil && !errors.Is(err, persisted_operations.ErrNoRemoteLoaderSpecified) {
 		log.Warn("Error initializing remote loader", "err", err)
 	}
 
 	po, err := persisted_operations.NewPersistedOperations(log, cfg.PersistedOperations, persisted_operations.NewLocalDirLoader(cfg.PersistedOperations), remoteLoader)
 	if err != nil {
-		log.Error("Error creating Persisted Operations", "err", err)
+		log.Error("Error initializing Persisted Operations", "err", err)
 		return nil
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -63,7 +63,8 @@ func TestHttpServerIntegration(t *testing.T) {
 					},
 				}
 				ex, _ := json.Marshal(expected)
-				actual, _ := io.ReadAll(response.Body)
+				actual, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
 				// perform string comparisons as map[string]interface seems incomparable
 				assert.Equal(t, string(ex), string(actual))
 			},
@@ -107,7 +108,9 @@ func TestHttpServerIntegration(t *testing.T) {
 					},
 				}
 				ex, _ := json.Marshal(expected)
-				actual, _ := io.ReadAll(response.Body)
+				actual, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+
 				ac := string(actual)
 				ac = strings.TrimSuffix(ac, "\n")
 
@@ -178,7 +181,7 @@ func TestHttpServerIntegration(t *testing.T) {
 
 				_, _ = w.Write(bts)
 			}))
-			defer mockServer.Close()
+			//defer mockServer.Close()
 
 			shutdown := make(chan os.Signal, 1)
 
@@ -195,7 +198,7 @@ func TestHttpServerIntegration(t *testing.T) {
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)
 			if err != nil {
-				assert.NoError(t, err)
+				assert.NoError(t, err, tt.name)
 			}
 
 			tt.want(t, res)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
 	"github.com/stretchr/testify/assert"
@@ -181,7 +180,7 @@ func TestHttpServerIntegration(t *testing.T) {
 
 				_, _ = w.Write(bts)
 			}))
-			//defer mockServer.Close()
+			defer mockServer.Close()
 
 			shutdown := make(chan os.Signal, 1)
 
@@ -192,7 +191,7 @@ func TestHttpServerIntegration(t *testing.T) {
 			cfg.Target.Host = mockServer.URL
 
 			go func() {
-				_ = run(context.Background(), slog.Default(), cfg, shutdown)
+				_ = run(slog.Default(), cfg, shutdown)
 			}()
 
 			url := "http://localhost:8080" + tt.args.request.URL.String()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -41,6 +41,7 @@ func TestHttpServerIntegration(t *testing.T) {
 				}(),
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
+					cfg.PersistedOperations.Store = "./"
 					return cfg
 				},
 				mockResponse: map[string]interface{}{
@@ -85,6 +86,7 @@ func TestHttpServerIntegration(t *testing.T) {
 				}(),
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
+					cfg.PersistedOperations.Store = "./"
 					return cfg
 				},
 				mockResponse: map[string]interface{}{
@@ -127,6 +129,8 @@ func TestHttpServerIntegration(t *testing.T) {
 				}(),
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
+					cfg.PersistedOperations.Store = "./"
+					cfg.PersistedOperations.FailUnknownOperations = false
 					return cfg
 				},
 				mockResponse: map[string]interface{}{
@@ -160,7 +164,8 @@ func TestHttpServerIntegration(t *testing.T) {
 					},
 				}
 				ex, _ := json.Marshal(expected)
-				actual, _ := io.ReadAll(response.Body)
+				actual, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
 				// perform string comparisons as map[string]interface seems incomparable
 				assert.Equal(t, string(ex), string(actual))
 			},

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -20,18 +20,28 @@ persisted_operations:
   enabled: true
   # Fail unknown operations, disable this feature to allow unknown operations to reach your GraphQL API
   fail_unknown_operations: true
-  # Determines the strategy for loading the supported operations.
-  # Only one store will be used
-  store:
-    # Load persisted operations from a directory on the local filesystem. 
-    # Will look at all files in the directory and attempt to load any file with a `.json` extension
-    dir: "./my-dir"
+  # Store is the location on local disk where go-graphql-armor can find the persisted operations, it loads any `*.json` files on disk
+  store: "./store"
+  reload:
+    enabled: true
+    interval: 5m
+    # The timeout for the remote operation
+    timeout: 10s
+  remote:
     # Load persisted operations from a GCP Cloud Storage bucket.
     # Will look at all the objects in the bucket and try to load any object with a `.json` extension
     gcp_bucket: "gs://somebucket"
 
 # ...
 ```
+
+## How it works
+
+`go-graphql-armor` looks at the store location on local disk to find any `*.json` files it can parse for persisted operations. 
+
+It can be configured to look at this directory and reload based on the files on local disk.
+
+Additionally, it can be configured to fetch operations from a remote location onto the local disk.
 
 ## Parsing Structure
 

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -24,6 +24,7 @@ persisted_operations:
   store: "./store"
   reload:
     enabled: true
+    # The interval in which the local store dir is read and refreshes the internal state
     interval: 5m
     # The timeout for the remote operation
     timeout: 10s
@@ -37,7 +38,7 @@ persisted_operations:
 
 ## How it works
 
-`go-graphql-armor` looks at the store location on local disk to find any `*.json` files it can parse for persisted operations. 
+`go-graphql-armor` looks at the `store` location on local disk to find any `*.json` files it can parse for persisted operations. 
 
 It can be configured to look at this directory and reload based on the files on local disk.
 

--- a/internal/business/block_field_suggestions/block_field_suggestions.go
+++ b/internal/business/block_field_suggestions/block_field_suggestions.go
@@ -51,13 +51,13 @@ func (b *BlockFieldSuggestionsHandler) processErrors(payload interface{}) interf
 func (b *BlockFieldSuggestionsHandler) processError(err map[string]interface{}) map[string]interface{} {
 	if msg, ok4 := err["message"]; ok4 {
 		if message, ok := msg.(string); ok {
-			err["message"] = b.ReplaceSuggestions(message)
+			err["message"] = b.replaceSuggestions(message)
 		}
 	}
 	return err
 }
 
-func (b *BlockFieldSuggestionsHandler) ReplaceSuggestions(message string) string {
+func (b *BlockFieldSuggestionsHandler) replaceSuggestions(message string) string {
 	if strings.HasPrefix(message, "Did you mean") {
 		return b.cfg.Mask
 	}

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -16,9 +16,9 @@ type DirLoader struct {
 	path string
 }
 
-func newDirLoader(cfg Config) *DirLoader {
+func NewLocalDirLoader(cfg Config) *DirLoader {
 	return &DirLoader{
-		path: cfg.Store.Dir,
+		path: cfg.Store,
 	}
 }
 

--- a/internal/business/persisted_operations/gcp_storage_loader.go
+++ b/internal/business/persisted_operations/gcp_storage_loader.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/api/iterator"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -17,9 +18,10 @@ import (
 type GcpStorageLoader struct {
 	client *storage.Client
 	bucket string
+	store  string
 }
 
-func NewGcpStorageLoader(ctx context.Context, bucket string, cfg Config) (*GcpStorageLoader, error) {
+func NewGcpStorageLoader(ctx context.Context, bucket string, store string) (*GcpStorageLoader, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -28,6 +30,7 @@ func NewGcpStorageLoader(ctx context.Context, bucket string, cfg Config) (*GcpSt
 	return &GcpStorageLoader{
 		client: client,
 		bucket: bucket,
+		store:  store,
 	}, nil
 }
 func (g *GcpStorageLoader) Load(ctx context.Context) error {
@@ -47,8 +50,7 @@ func (g *GcpStorageLoader) Load(ctx context.Context) error {
 
 		ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 
-		// include path
-		f, err := os.Create(attrs.Name)
+		f, err := os.Create(filepath.Join(g.store, attrs.Name))
 		if err != nil {
 			cancel()
 			errs = append(errs, fmt.Errorf("os.Create: %w", err))

--- a/internal/business/persisted_operations/loader.go
+++ b/internal/business/persisted_operations/loader.go
@@ -28,7 +28,7 @@ func RemoteLoaderFromConfig(cfg Config) (RemoteLoader, error) {
 // load loads persisted operations from various sources
 func determineLoader(cfg Config) (RemoteLoader, error) {
 	if cfg.Remote.GcpBucket != "" {
-		loader, err := NewGcpStorageLoader(context.Background(), cfg.Remote.GcpBucket, cfg)
+		loader, err := NewGcpStorageLoader(context.Background(), cfg.Remote.GcpBucket, cfg.Store)
 		if err != nil {
 			return nil, errors.New("unable to instantiate GcpBucketLoader")
 		}

--- a/internal/business/persisted_operations/memory_loader.go
+++ b/internal/business/persisted_operations/memory_loader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// MemoryLoader is a loader for testing purposes
+// MemoryLoader is a remoteLoader for testing purposes
 // It allows the user to specify operations in memory
 type MemoryLoader struct {
 	store map[string]string

--- a/internal/business/persisted_operations/memory_loader.go
+++ b/internal/business/persisted_operations/memory_loader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// MemoryLoader is a remoteLoader for testing purposes
+// MemoryLoader is a loader for testing purposes
 // It allows the user to specify operations in memory
 type MemoryLoader struct {
 	store map[string]string

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -92,7 +92,8 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 		}
 		return time.NewTicker(cfg.Reload.Interval)
 	}()
-	done := make(chan bool)
+	// buffered in case we dont have reloading enabled
+	done := make(chan bool, 1)
 
 	cache, err := loader.Load(context.Background())
 	if err != nil {

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -95,17 +95,10 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 	// buffered in case we dont have reloading enabled
 	done := make(chan bool, 1)
 
-	cache, err := loader.Load(context.Background())
-	if err != nil {
-		return nil, err
-	}
-
-	log.Info("Loaded persisted operations", "amount", len(cache))
-
 	poh := &PersistedOperationsHandler{
 		log:           log,
 		cfg:           cfg,
-		cache:         cache,
+		cache:         map[string]string{},
 		remoteLoader:  remoteLoader,
 		dirLoader:     loader,
 		refreshTicker: refreshTicker,
@@ -114,7 +107,7 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 	}
 
 	poh.reloadFromRemote()
-	err = poh.reloadFromLocalDir()
+	err := poh.reloadFromLocalDir()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync"
+	"time"
 )
 
 type RequestPayload struct {
@@ -29,20 +31,24 @@ type ErrorPayload struct {
 	} `json:"errors"`
 }
 
-type PersistedOperationsLoader interface {
-	Load(ctx context.Context) (map[string]string, error)
-}
-
 type Config struct {
 	Enabled bool `conf:"default:false" yaml:"enabled"`
-	Store   struct {
+	// The location on which persisted operations are stored
+	Store string `conf:"./store" yaml:"store"`
+	// Configuration for auto-reloading persisted operations
+	Reload struct {
+		Enabled  bool          `conf:"default:false" yaml:"enabled"`
+		Interval time.Duration `conf:"default:5m" yaml:"interval"`
+		Timeout  time.Duration `conf:"default:10s" yaml:"timeout"`
+	}
+	// Remote strategies for fetching persisted operations
+	Remote struct {
 		GcpBucket string `conf:"gs://something/foo" yaml:"gcp_bucket"`
-		Dir       string `conf:"" yaml:"dir"`
 	}
 	FailUnknownOperations bool `conf:"default:false" yaml:"fail_unknown_operations"`
 }
 
-var ErrNoLoaderSupplied = errors.New("no loader supplied")
+var ErrNoLoaderSupplied = errors.New("no remoteLoader supplied")
 var ErrNoHashFound = errors.New("no hash found")
 
 type PersistedOperationsHandler struct {
@@ -51,14 +57,37 @@ type PersistedOperationsHandler struct {
 	// this has the opportunity to grow indefinitely, might wat to replace with a fixed-cap cache
 	// or something like an LRU with a TTL
 	cache map[string]string
-	// not sure if keeping a reference to this is required, might be nice for refreshing during runtime
-	loader PersistedOperationsLoader
+	// Strategy for loading persisted operations from a remote location
+	remoteLoader  RemoteLoader
+	refreshTicker *time.Ticker
+
+	dirLoader LocalLoader
+	done      chan bool
+	lock      sync.RWMutex
 }
 
-func NewPersistedOperations(log *slog.Logger, cfg Config, loader PersistedOperationsLoader) (*PersistedOperationsHandler, error) {
+func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, remoteLoader RemoteLoader) (*PersistedOperationsHandler, error) {
 	if loader == nil {
 		return nil, ErrNoLoaderSupplied
 	}
+
+	if remoteLoader != nil {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, cfg.Reload.Timeout)
+		defer cancel()
+		err := remoteLoader.Load(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.Reload.Interval < 10*time.Second {
+		cfg.Reload.Interval = 10 * time.Second
+		log.Warn("Reload interval cannot be less than every 10 seconds, manually overwrote to 10 seconds")
+	}
+
+	refreshTicker := time.NewTicker(cfg.Reload.Interval)
+	done := make(chan bool)
 
 	cache, err := loader.Load(context.Background())
 	if err != nil {
@@ -67,12 +96,21 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader PersistedOperat
 
 	log.Info("Loaded persisted operations", "amount", len(cache))
 
-	return &PersistedOperationsHandler{
-		log:    log,
-		cfg:    cfg,
-		cache:  cache,
-		loader: loader,
-	}, nil
+	poh := &PersistedOperationsHandler{
+		log:           log,
+		cfg:           cfg,
+		cache:         cache,
+		remoteLoader:  remoteLoader,
+		dirLoader:     loader,
+		refreshTicker: refreshTicker,
+		done:          done,
+		lock:          sync.RWMutex{},
+	}
+
+	// start reloader
+	poh.reload()
+
+	return poh, nil
 }
 
 // Execute runs of the persisted operations handler
@@ -113,7 +151,10 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler {
 			return
 		}
 
+		p.lock.RLock()
 		query, ok := p.cache[hash]
+		p.lock.RUnlock()
+
 		if !ok {
 			// hash not found, fail
 			p.log.Warn("Unknown hash, persisted operation not found ", "hash", hash)
@@ -139,6 +180,62 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)
+}
+
+func (p *PersistedOperationsHandler) reloadFromLocalDir() error {
+	dirLoader := NewLocalDirLoader(p.cfg)
+	if dirLoader == nil {
+		return errors.New("dir loader is nil")
+	}
+
+	cache, err := dirLoader.Load(context.Background())
+	if err != nil {
+		return err
+	}
+	p.lock.Lock()
+	p.cache = cache
+	p.lock.Unlock()
+
+	p.log.Info("Loaded persisted operations", "amount", len(cache))
+
+	return nil
+}
+
+func (p *PersistedOperationsHandler) reload() {
+	if !p.cfg.Reload.Enabled {
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-p.done:
+				return
+			case _ = <-p.refreshTicker.C:
+				p.reloadFromRemote()
+			}
+		}
+	}()
+}
+
+func (p *PersistedOperationsHandler) reloadFromRemote() {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, p.cfg.Reload.Timeout)
+	err := p.remoteLoader.Load(ctx)
+	cancel()
+	if err != nil {
+		return
+	}
+
+	err = p.reloadFromLocalDir()
+	if err != nil {
+		p.log.Error("Error loading from local dir", "err", err)
+		return
+	}
+}
+
+func (p *PersistedOperationsHandler) Shutdown() {
+	p.done <- true
 }
 
 func hashFromPayload(payload RequestPayload) (string, error) {

--- a/internal/business/persisted_operations/persisted_operations_test.go
+++ b/internal/business/persisted_operations/persisted_operations_test.go
@@ -141,7 +141,7 @@ func TestNewPersistedOperations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := slog.Default()
-			po, _ := NewPersistedOperations(log, tt.args.cfg, newMemoryLoader(tt.args.cache))
+			po, _ := NewPersistedOperations(log, tt.args.cfg, newMemoryLoader(tt.args.cache), nil)
 			po.cache = tt.args.cache
 
 			bts, err := json.Marshal(&tt.args.payload)

--- a/internal/business/proxy/proxy.go
+++ b/internal/business/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,6 +40,7 @@ func NewProxy(cfg Config, blockFieldSuggestions *block_field_suggestions.BlockFi
 		}
 
 		decoder := json.NewDecoder(res.Body)
+		defer res.Body.Close()
 
 		var response map[string]interface{}
 		err := decoder.Decode(&response)
@@ -55,8 +57,9 @@ func NewProxy(cfg Config, blockFieldSuggestions *block_field_suggestions.BlockFi
 		}
 
 		buffer := bytes.NewBuffer(bts)
-		res.Body = io.NopCloser(buffer)
 		res.ContentLength = int64(buffer.Len())
+		res.Header.Set("Content-Length", strconv.Itoa(buffer.Len()))
+		res.Body = io.NopCloser(buffer)
 
 		return nil
 	}


### PR DESCRIPTION
Add feature to persisted operations that allows it to reload its store periodically.

- Persisted Operations now looks at a specific local directory for its data needs
- A Remote store can be configured to pull its data into the local directory
- An interval can be configured which pulls data from the remote, pushes it to the local disk and refreshes the internal store in memeory

Checklist

- [x] Update tests
- [x] Update documentation
