### PR TITLE
feat(max-aliases): Add max-aliases rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is dead-simple yet highly customizable security sidecar compatible with any H
 
 * [Persisted Operations](docs/persisted_operations.md)
 * [Block Field Suggestions](docs/block_field_suggestions.md)
-* _Max Aliases (coming soon)_
+* [Max Aliases](docs/max_aliases.md)
 * _Max Depth (coming soon)_
 * _Max Directives (coming soon)_
 * _Max Tokens (coming soon)_

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ It is dead-simple yet highly customizable security sidecar compatible with any H
 
 * [Persisted Operations](docs/persisted_operations.md)
 * [Block Field Suggestions](docs/block_field_suggestions.md)
-* More to come!
+* _Max Aliases (coming soon)_
+* _Max Depth (coming soon)_
+* _Max Directives (coming soon)_
+* _Max Tokens (coming soon)_
+* _Cost Limit (coming soon)_
 
 ## Installation
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -31,7 +31,7 @@ func TestHttpServerIntegration(t *testing.T) {
 			args: args{
 				request: func() *http.Request {
 					body := map[string]interface{}{
-						"query": "query { product(id: 1) { id name } }",
+						"query": "query Foo { product(id: 1) { id name } }",
 					}
 
 					bts, _ := json.Marshal(body)
@@ -122,7 +122,7 @@ func TestHttpServerIntegration(t *testing.T) {
 			args: args{
 				request: func() *http.Request {
 					body := map[string]interface{}{
-						"query": "query { product(id: 1) { id name } }",
+						"query": "query Foo { product(id: 1) { id name } }",
 					}
 
 					bts, _ := json.Marshal(body)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -172,6 +172,65 @@ func TestHttpServerIntegration(t *testing.T) {
 				assert.Equal(t, string(ex), string(actual))
 			},
 		},
+		{
+			name: "blocks requests with too many aliases",
+			args: args{
+				request: func() *http.Request {
+					body := map[string]interface{}{
+						"query": `
+query Foo { 
+	a1: uploadImage(image: $image)
+	a2: uploadImage(image: $image)
+	a3: uploadImage(image: $image)
+	a4: uploadImage(image: $image)
+	a5: uploadImage(image: $image)
+	a6: uploadImage(image: $image)
+	a7: uploadImage(image: $image)
+	a8: uploadImage(image: $image)
+	a9: uploadImage(image: $image)
+	a10: uploadImage(image: $image)
+}`,
+					}
+
+					bts, _ := json.Marshal(body)
+					r := httptest.NewRequest("POST", "/graphql", bytes.NewBuffer(bts))
+					return r
+				}(),
+				cfgOverrides: func(cfg *config.Config) *config.Config {
+					cfg.MaxAliases.Enabled = true
+					cfg.MaxAliases.Max = 3
+					return cfg
+				},
+				mockResponse: map[string]interface{}{
+					"data": map[string]interface{}{
+						"a1":  "Yes",
+						"a2":  "Yes",
+						"a3":  "Yes",
+						"a4":  "Yes",
+						"a5":  "Yes",
+						"a6":  "Yes",
+						"a7":  "Yes",
+						"a8":  "Yes",
+						"a9":  "Yes",
+						"a10": "Yes",
+					},
+				},
+			},
+			want: func(t *testing.T, response *http.Response) {
+				expected := map[string]interface{}{
+					"errors": []map[string]interface{}{
+						{
+							"message": "syntax error: Aliases limit of 3 exceeded, found 10",
+						},
+					},
+				}
+				_, _ = json.Marshal(expected)
+				actual, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				// perform string comparisons as map[string]interface seems incomparable
+				assert.True(t, errorsContainsMessage("syntax error: Aliases limit of 3 exceeded, found 10", actual))
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -206,4 +265,23 @@ func TestHttpServerIntegration(t *testing.T) {
 			shutdown <- syscall.SIGINT
 		})
 	}
+}
+
+func errorsContainsMessage(msg string, bytes []byte) bool {
+	var payload map[string]interface{}
+	err := json.Unmarshal(bytes, &payload)
+	if err != nil {
+		return false
+	}
+
+	if errors, ok := payload["errors"]; ok {
+		for _, err := range errors.([]interface{}) {
+			if errMsg, ok := err.(map[string]interface{})["message"]; ok {
+				if msg == errMsg {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/docs/max_aliases.md
+++ b/docs/max_aliases.md
@@ -1,0 +1,20 @@
+# Max Aliases
+
+Restricting the maximum number of aliases that are allowed within a single operation protects your API from Brute Force attacks.
+
+Aliases allow you to perform the same operation multiple times, within a single request. This opens up the possibility of for example trying out login operations 1000 times with 1 request. 
+Or even worse, uploading a 1 MB image with 1000 aliases in 1 request using the same binary data, essentially creating a Denial of Service attack on your API with 1MB of data, resulting in 1GB of data processed on the server.
+
+<!-- TOC -->
+
+## Configuration
+
+You can configure `go-graphql-armor` to limit the maximum number of aliases allowed on an operation.
+
+```yaml
+max_aliases:
+  # Enable the feature
+  enable: true
+  # The maximum number of allowed aliases within a single request.
+  max: 15
+```

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.1 h1:SBWmZhjUDRorQxrN0nw
 github.com/googleapis/enterprise-certificate-proxy v0.3.1/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/ardanlabs/conf/v3"
 	"github.com/ardanlabs/conf/v3/yaml"
+	"github.com/ldebruijn/go-graphql-armor/internal/business/aliases"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/persisted_operations"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/proxy"
@@ -26,6 +27,7 @@ type Config struct {
 	Target                proxy.Config                   `yaml:"target"`
 	PersistedOperations   persisted_operations.Config    ` yaml:"persisted_operations"`
 	BlockFieldSuggestions block_field_suggestions.Config `yaml:"block_field_suggestions"`
+	MaxAliases            aliases.Config                 `yaml:"max_aliases"`
 }
 
 func NewConfig() (*Config, error) {

--- a/internal/business/aliases/aliases.go
+++ b/internal/business/aliases/aliases.go
@@ -1,0 +1,108 @@
+package aliases
+
+import (
+	"fmt"
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/graphql-go/graphql/language/visitor"
+	"sync"
+)
+
+type Config struct {
+	max int `conf:"default:15" yaml:"max"`
+}
+
+var addRule sync.Once
+
+type MaxAliasesRule struct {
+	cfg Config
+}
+
+func NewMaxAliases() (*MaxAliasesRule, error) {
+
+	addRule.Do(func() {
+		r := MaxAliasesRule{}
+		graphql.SpecifiedRules = append(graphql.SpecifiedRules, r.validate)
+	})
+	return nil, nil
+}
+
+func (a *MaxAliasesRule) validate(context *graphql.ValidationContext) *graphql.ValidationRuleInstance {
+	instance := a.newMaxRuleInstance(a.cfg, context)
+	return &graphql.ValidationRuleInstance{VisitorOpts: instance.visitorOptions()}
+}
+
+type maxAliasesRuleInstance struct {
+	visitedFragments  map[string]int
+	cfg               Config
+	validationContext *graphql.ValidationContext
+}
+
+func (a *MaxAliasesRule) newMaxRuleInstance(cfg Config, validationContext *graphql.ValidationContext) *maxAliasesRuleInstance {
+	return &maxAliasesRuleInstance{
+		visitedFragments:  map[string]int{},
+		cfg:               cfg,
+		validationContext: validationContext,
+	}
+}
+
+func (a *maxAliasesRuleInstance) visitorOptions() *visitor.VisitorOptions {
+	return &visitor.VisitorOptions{
+		KindFuncMap: map[string]visitor.NamedVisitFuncs{
+			kinds.OperationDefinition: {
+				Enter: a.onOperationDefinitionEnter,
+				//Leave: a.onOperationDefinitionLeave,
+			},
+		},
+	}
+}
+
+func (i *maxAliasesRuleInstance) onOperationDefinitionEnter(p visitor.VisitFuncParams) (string, interface{}) {
+	od, ok := p.Node.(*ast.OperationDefinition)
+	if !ok {
+		return visitor.ActionSkip, nil
+	}
+
+	aliases := i.countAliases(p.Node)
+
+	if aliases > i.cfg.max {
+		err := fmt.Sprintf("syntax Error: Aliases limit of %d exceeded, found %d", i.cfg.max, aliases)
+
+		i.validationContext.ReportError(gqlerrors.NewError(err, []ast.Node{od}, "", nil, []int{}, nil))
+	}
+	return visitor.ActionNoChange, nil
+}
+
+func (i *maxAliasesRuleInstance) countAliases(node interface{}) int {
+	aliases := 0
+
+	switch node.(type) {
+	case ast.Field:
+		if node.(ast.Field).Alias != nil {
+			aliases++
+		}
+	case ast.SelectionSet:
+		for _, child := range node.(ast.SelectionSet).Selections {
+			aliases += i.countAliases(child)
+		}
+	case ast.FragmentSpread:
+		value := node.(ast.FragmentSpread).Name.Value
+		if val, ok := i.visitedFragments[value]; ok {
+			return val
+		} else {
+			i.visitedFragments[value] = -1
+		}
+
+		if fragment := i.validationContext.Fragment(value); fragment != nil {
+			additionalAliases := i.countAliases(fragment)
+			if i.visitedFragments[value] == -1 {
+				i.visitedFragments[value] = additionalAliases
+			}
+			aliases += additionalAliases
+		}
+	}
+
+	return aliases
+}

--- a/internal/business/aliases/aliases_test.go
+++ b/internal/business/aliases/aliases_test.go
@@ -54,7 +54,7 @@ func Test_MaxAliasesRule(t *testing.T) {
 				query:  query,
 				schema: queryType,
 				cfg: Config{
-					max: 15,
+					Max: 15,
 				},
 			},
 			want: nil,
@@ -63,7 +63,7 @@ func Test_MaxAliasesRule(t *testing.T) {
 			name: "produces error when counted aliases are more than configured maximum",
 			args: args{
 				cfg: Config{
-					1,
+					Max: 1,
 				},
 				query:  query,
 				schema: queryType,
@@ -86,7 +86,7 @@ query A {
 `,
 				schema: queryType,
 				cfg: Config{
-					1,
+					Max: 1,
 				},
 			},
 			want: fmt.Errorf("syntax error: Aliases limit of %d exceeded, found %d", 1, 2),
@@ -135,7 +135,7 @@ query {
 					return queryType
 				}(),
 				cfg: Config{
-					3,
+					Max: 3,
 				},
 			},
 			want: fmt.Errorf("Cannot spread fragment \"%s\" within itself via %s.", "A", "B"),
@@ -146,9 +146,9 @@ query {
 			astDoc := parseQuery(t, tt.args.query)
 			schema, _ := graphql.NewSchema(graphql.SchemaConfig{Query: graphql.NewObject(tt.args.schema)})
 
-			ma, _ := NewMaxAliases(tt.args.cfg)
+			ma := NewMaxAliasesRule(tt.args.cfg)
 
-			vr := graphql.ValidateDocument(&schema, astDoc, []graphql.ValidationRuleFn{graphql.NoFragmentCyclesRule, ma.validate})
+			vr := graphql.ValidateDocument(&schema, astDoc, []graphql.ValidationRuleFn{graphql.NoFragmentCyclesRule, ma.Validate})
 			errs := vr.Errors
 			if tt.want != nil {
 				assert.Equal(t, tt.want.Error(), errs[0].Message)

--- a/internal/business/aliases/aliases_test.go
+++ b/internal/business/aliases/aliases_test.go
@@ -1,0 +1,172 @@
+package aliases
+
+import (
+	"fmt"
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_MaxAliasesRule(t *testing.T) {
+	query := `query {
+    firstBooks: getBook(title: "null") {
+      author
+      title
+    }
+    secondBooks: getBook(title: "null") {
+      author
+      title
+    }
+  }`
+
+	bookType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Book",
+		Fields: graphql.Fields{
+			"title":  &graphql.Field{Type: graphql.String},
+			"author": &graphql.Field{Type: graphql.String},
+		},
+	})
+
+	queryType := graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"books": &graphql.Field{
+				Type: bookType,
+			},
+		},
+	}
+
+	type args struct {
+		query  string
+		schema graphql.ObjectConfig
+		cfg    Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want error
+	}{
+		{
+			name: "no aliases yields zero count",
+			args: args{
+				query:  query,
+				schema: queryType,
+				cfg: Config{
+					max: 15,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "produces error when counted aliases are more than configured maximum",
+			args: args{
+				cfg: Config{
+					1,
+				},
+				query:  query,
+				schema: queryType,
+			},
+			want: fmt.Errorf("syntax error: Aliases limit of %d exceeded, found %d", 1, 2),
+		},
+		{
+			name: "respects fragment aliases",
+			args: args{
+				query: `
+query A {
+        getBook(title: "null") {
+          firstTitle: title
+          ...BookFragment
+        }
+      }
+      fragment BookFragment on Book {
+        secondTitle: title
+      }
+`,
+				schema: queryType,
+				cfg: Config{
+					1,
+				},
+			},
+			want: fmt.Errorf("syntax error: Aliases limit of %d exceeded, found %d", 1, 2),
+		},
+		{
+			name: "does not crash on recursive fragments",
+			args: args{
+				query: `
+query {
+        ...A
+      }
+
+      fragment A on Query {
+        ...B
+      }
+
+      fragment B on Query {
+        ...A
+      }
+`,
+				schema: func() graphql.ObjectConfig {
+					aFragment := graphql.NewObject(graphql.ObjectConfig{
+						Name: "A",
+						//Fields: graphql.Fields{
+						//	"B": &graphql.Field{Type: bFragment},
+						//},
+					})
+
+					bFragment := graphql.NewObject(graphql.ObjectConfig{
+						Name: "B",
+						Fields: graphql.Fields{
+							"A": &graphql.Field{Type: aFragment},
+						},
+					})
+
+					aFragment.AddFieldConfig("B", &graphql.Field{Type: bFragment})
+
+					queryType := graphql.ObjectConfig{
+						Name: "Query",
+						Fields: graphql.Fields{
+							"A": &graphql.Field{
+								Type: aFragment,
+							},
+						},
+					}
+					return queryType
+				}(),
+				cfg: Config{
+					3,
+				},
+			},
+			want: fmt.Errorf("cannot spread fragment %s within itself via %s", "A", "B"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			astDoc := parseQuery(t, tt.args.query)
+			schema, _ := graphql.NewSchema(graphql.SchemaConfig{Query: graphql.NewObject(tt.args.schema)})
+			typeInfo := graphql.NewTypeInfo(&graphql.TypeInfoConfig{Schema: &schema})
+			ctx := graphql.NewValidationContext(&schema, astDoc, typeInfo)
+
+			ma, _ := NewMaxAliases(tt.args.cfg)
+			mai := ma.newMaxRuleInstance(ma.cfg, ctx)
+			visitor.Visit(astDoc, mai.visitorOptions(), nil)
+
+			errs := mai.validationContext.Errors()
+
+			if tt.want != nil {
+				assert.Equal(t, tt.want.Error(), errs[0].Message)
+			}
+		})
+	}
+}
+
+func parseQuery(t *testing.T, q string) *ast.Document {
+	t.Helper()
+	astDoc, err := parser.Parse(parser.ParseParams{Source: q})
+	if err != nil {
+		t.Fatalf("parse failed: %s", err)
+	}
+	return astDoc
+}

--- a/internal/business/gql/gql.go
+++ b/internal/business/gql/gql.go
@@ -1,0 +1,39 @@
+package gql
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type RequestPayload struct {
+	//OperationName string      `json:"operationName"`
+	Variables  interface{} `json:"variables"`
+	Query      string      `json:"query"`
+	Extensions Extensions  `json:"extensions"`
+}
+
+type Extensions struct {
+	PersistedQuery *PersistedQuery `json:"persistedQuery"`
+}
+
+type PersistedQuery struct {
+	Sha256Hash string `json:"sha256Hash"`
+}
+
+func ParseRequestPayload(r *http.Request) (RequestPayload, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return RequestPayload{}, err
+	}
+	// Replace the body with a new reader after reading from the original
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	var payload RequestPayload
+	err = json.Unmarshal(body, &payload)
+	if err != nil {
+		return RequestPayload{}, err
+	}
+	return payload, nil
+}

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -25,7 +25,11 @@ func NewLocalDirLoader(cfg Config) *DirLoader {
 func (d *DirLoader) Load(ctx context.Context) (map[string]string, error) {
 	files, err := os.ReadDir(d.path)
 	if err != nil {
-		return nil, err
+		// if we can't read the dir, try creating it
+		err := os.Mkdir(d.path, 0750)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var result map[string]string

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -94,14 +94,16 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 		lock:          sync.RWMutex{},
 	}
 
-	poh.reloadFromRemote()
-	err := poh.reloadFromLocalDir()
-	if err != nil {
-		return nil, err
-	}
+	if cfg.Enabled {
+		poh.reloadFromRemote()
+		err := poh.reloadFromLocalDir()
+		if err != nil {
+			return nil, err
+		}
 
-	// start reloader
-	poh.reload()
+		// start reloader
+		poh.reload()
+	}
 
 	return poh, nil
 }

--- a/internal/business/persisted_operations/persisted_operations_test.go
+++ b/internal/business/persisted_operations/persisted_operations_test.go
@@ -3,6 +3,7 @@ package persisted_operations
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
 	"github.com/stretchr/testify/assert"
 	"log/slog"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 func TestNewPersistedOperations(t *testing.T) {
 	type args struct {
 		cfg     Config
-		payload RequestPayload
+		payload gql.RequestPayload
 		cache   map[string]string
 	}
 	tests := []struct {
@@ -45,7 +46,7 @@ func TestNewPersistedOperations(t *testing.T) {
 					Enabled:               true,
 					FailUnknownOperations: true,
 				},
-				payload: RequestPayload{
+				payload: gql.RequestPayload{
 					Query: "query { foo }",
 				},
 			},
@@ -53,7 +54,7 @@ func TestNewPersistedOperations(t *testing.T) {
 				fn := func(w http.ResponseWriter, r *http.Request) {
 					decoder := json.NewDecoder(r.Body)
 
-					var payload RequestPayload
+					var payload gql.RequestPayload
 					err := decoder.Decode(&payload)
 					assert.NoError(t, err)
 
@@ -72,9 +73,9 @@ func TestNewPersistedOperations(t *testing.T) {
 					Enabled:               true,
 					FailUnknownOperations: false,
 				},
-				payload: RequestPayload{
-					Extensions: Extensions{
-						PersistedQuery: &PersistedQuery{
+				payload: gql.RequestPayload{
+					Extensions: gql.Extensions{
+						PersistedQuery: &gql.PersistedQuery{
 							Sha256Hash: "foobar",
 						},
 					},
@@ -106,9 +107,9 @@ func TestNewPersistedOperations(t *testing.T) {
 					Enabled:               true,
 					FailUnknownOperations: false,
 				},
-				payload: RequestPayload{
-					Extensions: Extensions{
-						PersistedQuery: &PersistedQuery{
+				payload: gql.RequestPayload{
+					Extensions: gql.Extensions{
+						PersistedQuery: &gql.PersistedQuery{
 							Sha256Hash: "foobar",
 						},
 					},
@@ -121,7 +122,7 @@ func TestNewPersistedOperations(t *testing.T) {
 				fn := func(w http.ResponseWriter, r *http.Request) {
 					decoder := json.NewDecoder(r.Body)
 
-					var payload RequestPayload
+					var payload gql.RequestPayload
 					err := decoder.Decode(&payload)
 					assert.NoError(t, err)
 


### PR DESCRIPTION
Resolves #2 

Adds support for max-aliases rule. This counts the number of aliases in an operation and throws an error if it exceeds the configured maximum.

- [x] Utilizes go-graphql ValidationRule feature
- [x] Count aliases 
- [x] Test cases
- [x] Update/Add documentation