### PR TITLE
feat(optional-reject-on-failure): Add reject-on-failure option. Add documentation on metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"github.com/ardanlabs/conf/v3"
 	"github.com/graphql-go/graphql"
@@ -29,6 +30,7 @@ import (
 
 var (
 	build       = "develop"
+	configPath  = ""
 	httpCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "go_graphql_armor",
 		Subsystem: "http",
@@ -52,10 +54,13 @@ func init() {
 }
 
 func main() {
+	flag.StringVar(&configPath, "f", "./armor.yml", "Defines the path at which the configuration file can be found")
+	flag.Parse()
+
 	log := slog.Default()
 
 	// cfg
-	cfg, err := config.NewConfig()
+	cfg, err := config.NewConfig(configPath)
 	if err != nil {
 		log.Error("Error loading application configuration", "err", err)
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	middleware2 "github.com/ldebruijn/go-graphql-armor/internal/business/middleware"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/persisted_operations"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/proxy"
+	"github.com/ldebruijn/go-graphql-armor/internal/business/readiness"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log2 "log"
@@ -108,6 +109,7 @@ func run(log *slog.Logger, cfg *config.Config, shutdown chan os.Signal) error {
 	mid := middleware(log, cfg, po)
 
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/internal/healthz/readiness", readiness.NewReadinessHandler())
 	mux.Handle(cfg.Web.Path, mid(Handler(pxy)))
 
 	api := http.Server{

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -240,7 +241,6 @@ query Foo {
 
 				_, _ = w.Write(bts)
 			}))
-			defer mockServer.Close()
 
 			shutdown := make(chan os.Signal, 1)
 
@@ -272,9 +272,10 @@ query Foo {
 			tt.want(t, res)
 
 			// cleanup
-			defer func() {
-				//shutdown <- syscall.SIGINT
-			}()
+			t.Cleanup(func() {
+				mockServer.Close()
+				shutdown <- syscall.SIGINT
+			})
 		})
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
 	"github.com/stretchr/testify/assert"
 	"io"
-	log2 "log"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -258,21 +257,17 @@ query Foo {
 			// block test case until server has started
 			blockUntilStarted(httptest.NewRequest("GET", "/", nil), 1*time.Second)
 
-			log2.Println("server has started")
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)
-			log2.Println("fired request")
-			if err != nil {
-				assert.NoError(t, err, tt.name)
-			}
+
+			assert.NoError(t, err, tt.name)
 
 			tt.want(t, res)
-			log2.Println("finished assertions")
-
-			log2.Println("initiating shutdown")
 
 			// cleanup
-			shutdown <- syscall.SIGINT
+			defer func() {
+				shutdown <- syscall.SIGINT
+			}()
 		})
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -241,6 +241,7 @@ query Foo {
 
 				_, _ = w.Write(bts)
 			}))
+			defer mockServer.Close()
 
 			shutdown := make(chan os.Signal, 1)
 
@@ -273,10 +274,7 @@ query Foo {
 			tt.want(t, res)
 
 			// cleanup
-			t.Cleanup(func() {
-				mockServer.Close()
-				shutdown <- syscall.SIGINT
-			})
+			shutdown <- syscall.SIGINT
 		})
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -274,7 +273,7 @@ query Foo {
 
 			// cleanup
 			defer func() {
-				shutdown <- syscall.SIGINT
+				//shutdown <- syscall.SIGINT
 			}()
 		})
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
 	"github.com/stretchr/testify/assert"
 	"io"
+	log2 "log"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -257,13 +258,18 @@ query Foo {
 			// block test case until server has started
 			blockUntilStarted(httptest.NewRequest("GET", "/", nil), 1*time.Second)
 
+			log2.Println("server has started")
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)
+			log2.Println("fired request")
 			if err != nil {
 				assert.NoError(t, err, tt.name)
 			}
 
 			tt.want(t, res)
+			log2.Println("finished assertions")
+
+			log2.Println("initiating shutdown")
 
 			// cleanup
 			shutdown <- syscall.SIGINT

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -261,6 +261,7 @@ query Foo {
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)
 
 			assert.NoError(t, err, tt.name)
+			assert.NotNil(t, res, "response was nil", tt.name)
 
 			tt.want(t, res)
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -251,7 +251,8 @@ query Foo {
 			cfg.Target.Host = mockServer.URL
 
 			go func() {
-				_ = run(slog.Default(), cfg, shutdown)
+				err := run(slog.Default(), cfg, shutdown)
+				assert.NoError(t, err, "error starting server for", tt.name)
 			}()
 
 			start := time.Now()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
 	"github.com/stretchr/testify/assert"
 	"io"
+	log2 "log"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -254,8 +255,14 @@ query Foo {
 				_ = run(slog.Default(), cfg, shutdown)
 			}()
 
+			start := time.Now()
+
 			// block test case until server has started
+			log2.Println("Waiting until server has started")
+
 			blockUntilStarted(httptest.NewRequest("GET", "/", nil), 1*time.Second)
+
+			log2.Printf("Waiting until server has started, took %s \n", time.Since(start))
 
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -256,8 +256,6 @@ query Foo {
 
 			// block test case until server has started
 			blockUntilStarted(httptest.NewRequest("GET", "/", nil), 1*time.Second)
-			//tiny sleep to make sure HTTP server has started
-			//time.Sleep(100 * time.Millisecond)
 
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -261,7 +261,7 @@ query Foo {
 
 			blockUntilStarted(httptest.NewRequest("GET", "/", nil), 1*time.Second)
 
-			log2.Printf("Waiting until server has started, took %s \n", time.Since(start))
+			log2.Printf("Server has started, took %s \n", time.Since(start))
 
 			url := "http://localhost:8080" + tt.args.request.URL.String()
 			res, err := http.Post(url, tt.args.request.Header.Get("Content-Type"), tt.args.request.Body)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -244,7 +244,7 @@ query Foo {
 
 			shutdown := make(chan os.Signal, 1)
 
-			defaultConfig, _ := config.NewConfig()
+			defaultConfig, _ := config.NewConfig("")
 			cfg := tt.args.cfgOverrides(defaultConfig)
 
 			// set target to mockserver

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -275,6 +275,10 @@ query Foo {
 
 			// cleanup
 			shutdown <- syscall.SIGINT
+
+			// give time for server to shutdown
+			log2.Println("Waiting until server has shut down")
+			time.Sleep(100 * time.Millisecond)
 		})
 	}
 }

--- a/docs/block_field_suggestions.md
+++ b/docs/block_field_suggestions.md
@@ -21,3 +21,20 @@ block_field_suggestions:
 ## How does it work?
 
 We scan each `errors[].message` field in the responses and replace the message with a mask when we encounter a field suggestion.
+
+## Metrics
+
+
+## Metrics
+
+This rule produces metrics to help you gain insights into the behavior of the rule.
+
+```
+go_graphql_armor_block_field_suggestions_results{result}
+```
+
+`result`:
+`masked` means the rule found suggestions and masked the error message
+`unmasked` means the rule found no suggestions and did not alter the response
+
+No metrics are produced when the rule is disabled.

--- a/docs/block_field_suggestions.md
+++ b/docs/block_field_suggestions.md
@@ -33,8 +33,10 @@ This rule produces metrics to help you gain insights into the behavior of the ru
 go_graphql_armor_block_field_suggestions_results{result}
 ```
 
-`result`:
-`masked` means the rule found suggestions and masked the error message
-`unmasked` means the rule found no suggestions and did not alter the response
+| `result`   | Description                                                         |
+|----------|---------------------------------------------------------------------|
+| `masked`   | The rule found suggestions and masked the error message             |
+| `unmasked` | means the rule found no suggestions and did not alter the response  |
+
 
 No metrics are produced when the rule is disabled.

--- a/docs/max_aliases.md
+++ b/docs/max_aliases.md
@@ -29,9 +29,11 @@ This rule produces metrics to help you gain insights into the behavior of the ru
 go_graphql_armor_max_aliases_results{result}
 ```
 
-`result`:
-`rejected` means the rule condition failed and the request was rejected
-`failed` means the rule condition failed but the request was not rejected. This happens when `reject_on_failure` is `false`
-`allowd` means the rule condition succeeded
+
+| `result`  | Description                                                                                                  |
+|---------|--------------------------------------------------------------------------------------------------------------|
+| `allowed` | The rule condition succeeded                                                                                 |
+| `rejected` | The rule condition failed and the request was rejected                                                       |
+| `failed` | The rule condition failed but the request was not rejected. This happens when `reject_on_failure` is `false` |
 
 No metrics are produced when the rule is disabled.

--- a/docs/max_aliases.md
+++ b/docs/max_aliases.md
@@ -17,4 +17,21 @@ max_aliases:
   enable: true
   # The maximum number of allowed aliases within a single request.
   max: 15
+  # Reject the request when the rule fails. Disable this to allow the request
+  reject_on_failure: true
 ```
+
+## Metrics
+
+This rule produces metrics to help you gain insights into the behavior of the rule.
+
+```
+go_graphql_armor_max_aliases_results{result}
+```
+
+`result`:
+`rejected` means the rule condition failed and the request was rejected
+`failed` means the rule condition failed but the request was not rejected. This happens when `reject_on_failure` is `false`
+`allowd` means the rule condition succeeded
+
+No metrics are produced when the rule is disabled.

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -78,3 +78,31 @@ For this reason we do not deem APQ a good practice, and have chosen not to suppo
 In order to utilize this feature you need to generate the persisted operations that each client can perform.
 
 [GraphQL Code Generator](https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#persisted-documents)
+
+
+## Metrics
+
+This rule produces metrics to help you gain insights into the behavior of the rule.
+
+```
+go_graphql_armor_persisted_operations_results{state, result}
+```
+
+`state`:
+`unknown` means the rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request.
+`errored` means the rule caught an error during request body mutation.
+`known` means the rule received a hash for which it had a known operation
+
+`result`:
+`allowed` means the rule allowed the request
+`rejected` means the rule rejected the request
+
+```
+go_graphql_armor_persisted_operations_reload{system}
+```
+
+`system`:
+`local` means the system reloaded its state from local storage
+`remote` means the system reloaded the remote state onto local file storage. This does not refresh the local state on its own.
+
+No metrics are produced when the rule is disabled.

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -88,21 +88,26 @@ This rule produces metrics to help you gain insights into the behavior of the ru
 go_graphql_armor_persisted_operations_results{state, result}
 ```
 
-`state`:
-`unknown` means the rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request.
-`errored` means the rule caught an error during request body mutation.
-`known` means the rule received a hash for which it had a known operation
+| `state`    | Description                                                                                                                                                   |
+|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `unknown`   | The rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request. |
+| `errored` | The rule caught an error during request body mutation.                                                                                                        |
+| `known` | The rule received a hash for which it had a known operation                                                                                                   |
 
-`result`:
-`allowed` means the rule allowed the request
-`rejected` means the rule rejected the request
+
+| `result`  | Description                   |
+|---------|-------------------------------|
+| `allowed` | The rule allowed the request  |
+| `rejected` | The rule rejected the request |
 
 ```
 go_graphql_armor_persisted_operations_reload{system}
 ```
 
-`system`:
-`local` means the system reloaded its state from local storage
-`remote` means the system reloaded the remote state onto local file storage. This does not refresh the local state on its own.
+
+| `system` | Description                                                                                           |
+|--------|-------------------------------------------------------------------------------------------------------|
+| `local`  | The rule reloaded its state from local storage                                                        |
+| `remote` | The rule reloaded the remote state onto local disk. This does not refresh the local state on its own. |
 
 No metrics are produced when the rule is disabled.

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -30,11 +30,11 @@ type Config struct {
 	MaxAliases            aliases.Config                 `yaml:"max_aliases"`
 }
 
-func NewConfig() (*Config, error) {
+func NewConfig(configPath string) (*Config, error) {
 	cfg := Config{}
 
 	// ignore yaml read failure
-	fromYaml, _ := os.ReadFile("./armor.yml")
+	fromYaml, _ := os.ReadFile(configPath)
 
 	help, err := conf.Parse("go-graphql-armor", &cfg, yaml.WithData(fromYaml))
 	if err != nil {

--- a/internal/business/aliases/aliases_test.go
+++ b/internal/business/aliases/aliases_test.go
@@ -60,15 +60,28 @@ func Test_MaxAliasesRule(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "produces error when counted aliases are more than configured maximum",
+			name: "produces error when counted aliases are more than configured maximum and reject on failure is true",
 			args: args{
 				cfg: Config{
-					Max: 1,
+					Max:             1,
+					RejectOnFailure: true,
 				},
 				query:  query,
 				schema: queryType,
 			},
 			want: fmt.Errorf("syntax error: Aliases limit of %d exceeded, found %d", 1, 2),
+		},
+		{
+			name: "does not produce error when counted aliases are more than configured maximum and reject on failure is false",
+			args: args{
+				cfg: Config{
+					Max:             1,
+					RejectOnFailure: false,
+				},
+				query:  query,
+				schema: queryType,
+			},
+			want: nil,
 		},
 		{
 			name: "respects fragment aliases",
@@ -86,7 +99,8 @@ query A {
 `,
 				schema: queryType,
 				cfg: Config{
-					Max: 1,
+					Max:             1,
+					RejectOnFailure: true,
 				},
 			},
 			want: fmt.Errorf("syntax error: Aliases limit of %d exceeded, found %d", 1, 2),

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -21,7 +21,7 @@ var (
 		Name:      "counter",
 		Help:      "The results of the persisted operations rule",
 	},
-		[]string{"state", "allowed"},
+		[]string{"state", "result"},
 	)
 	reloadGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   "go_graphql_armor",
@@ -156,7 +156,7 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler {
 
 		hash, err := hashFromPayload(payload)
 		if err != nil {
-			persistedOpsCounter.WithLabelValues("unknown", "blocked").Inc()
+			persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
 			p.log.Warn("no hash found ", "err", err)
 			res, _ := json.Marshal(buildErrorResponse("PersistedQueryNotFound"))
 			http.Error(w, string(res), 200)
@@ -169,7 +169,7 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler {
 
 		if !ok {
 			// hash not found, fail
-			persistedOpsCounter.WithLabelValues("unknown", "blocked").Inc()
+			persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
 			p.log.Warn("Unknown hash, persisted operation not found ", "hash", hash)
 			res, _ := json.Marshal(buildErrorResponse("PersistedOperationNotFound"))
 			http.Error(w, string(res), 200)

--- a/internal/business/readiness/readiness.go
+++ b/internal/business/readiness/readiness.go
@@ -1,0 +1,13 @@
+package readiness
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func NewReadinessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "I'm ready!")
+	}
+}

--- a/internal/business/readiness/readiness_test.go
+++ b/internal/business/readiness/readiness_test.go
@@ -1,0 +1,37 @@
+package readiness
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewReadinessHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		want func(t *testing.T, res *http.Response)
+	}{
+		{
+			name: "Sends a 200 status code with an \"I'm ready!\" body",
+			want: func(t *testing.T, res *http.Response) {
+				assert.Equal(t, http.StatusOK, res.StatusCode)
+				payload, _ := io.ReadAll(res.Body)
+				assert.Equal(t, "I'm ready!", string(payload))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+
+			handler := NewReadinessHandler()
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			tt.want(t, resp.Result())
+		})
+	}
+}


### PR DESCRIPTION
- Adds `reject-on-failure` configuration option for max-alias feature.
- Documents metrics per feature
- Aligns metrics a bit more
- Add console argument configuration option for specifying configuration file location
- Add readiness endpoint