### PR TITLE
Fix gauges, add App-Info metric and reduce max-token default limit

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,10 +53,19 @@ var (
 	},
 		[]string{"route"},
 	)
+
+	appInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "go_graphql_armor",
+		Subsystem: "app",
+		Name:      "info",
+		Help:      "Application information",
+	},
+		[]string{"version", "go_version"},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(httpCounter, httpDuration)
+	prometheus.MustRegister(httpCounter, httpDuration, appInfo)
 }
 
 func main() {
@@ -75,6 +84,11 @@ func main() {
 	log2.Println(cfgAsString)
 
 	log.Info("Starting service", "version", build)
+
+	appInfo.With(prometheus.Labels{
+		"version":    build,
+		"go_version": runtime.Version(),
+	})
 
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)

--- a/docs/max_tokens.md
+++ b/docs/max_tokens.md
@@ -14,7 +14,7 @@ max_tokens:
   # Enable the feature
   enable: "true"
   # The maximum number of allowed tokens within a single request.
-  max: 10000
+  max: 1000
   # Reject the request when the rule fails. Disable this to allow the request regardless of token count.
   reject_on_failure: "true"
 ```

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -208,7 +208,7 @@ func (p *PersistedOperationsHandler) reloadFromLocalDir() error {
 	p.lock.Unlock()
 
 	p.log.Info("Loaded persisted operations", "amount", len(cache))
-	reloadGauge.WithLabelValues("local").Inc()
+	reloadGauge.WithLabelValues("local").Set(1)
 
 	return nil
 }
@@ -229,7 +229,7 @@ func (p *PersistedOperationsHandler) reload() {
 				if err != nil {
 					p.log.Warn("Error loading from local dir", "err", err)
 				}
-				reloadGauge.WithLabelValues("ticker").Inc()
+				reloadGauge.WithLabelValues("ticker").Set(1)
 			}
 		}
 	}()
@@ -248,7 +248,7 @@ func (p *PersistedOperationsHandler) reloadFromRemote() {
 		return
 	}
 
-	reloadGauge.WithLabelValues("remote").Inc()
+	reloadGauge.WithLabelValues("remote").Set(1)
 }
 
 func (p *PersistedOperationsHandler) Shutdown() {

--- a/internal/business/tokens/tokens.go
+++ b/internal/business/tokens/tokens.go
@@ -18,7 +18,7 @@ var resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 
 type Config struct {
 	Enabled         bool `conf:"default:true" yaml:"enabled"`
-	Max             int  `conf:"default:10000" yaml:"max"`
+	Max             int  `conf:"default:1000" yaml:"max"`
 	RejectOnFailure bool `conf:"default:true" yaml:"reject-on-failure"`
 }
 


### PR DESCRIPTION
Number of small additions and fixes:
- Fix gauge measures to behave like gauges, instead of counters
- Add app-info gauge with information about go-graphql-armor
- Reduce default max-token config to a more sane number