### PR TITLE
Fix max tokens config mapping and reject_on_failure property

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,7 +182,7 @@ func middleware(log *slog.Logger, cfg *config.Config, po *persisted_operations.P
 	httpInstrumentation := HttpInstrumentation()
 
 	aliases.NewMaxAliasesRule(cfg.MaxAliases)
-	tks := tokens.MaxTokens(cfg.Token)
+	tks := tokens.MaxTokens(cfg.MaxTokens)
 	vr := ValidationRules(schema, tks)
 
 	fn := func(next http.Handler) http.Handler {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -425,8 +425,8 @@ type Product {
 }
 `,
 				cfgOverrides: func(cfg *config.Config) *config.Config {
-					cfg.Token.Enabled = true
-					cfg.Token.Max = 1
+					cfg.MaxTokens.Enabled = true
+					cfg.MaxTokens.Max = 1
 					return cfg
 				},
 				mockResponse: map[string]interface{}{

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -27,10 +27,10 @@ type Config struct {
 		//DebugHost       string        `conf:"default:0.0.0.0:4000"`
 	}
 	Schema                schema.Config                  `yaml:"schema"`
-	Token                 tokens.Config                  `yaml:"token"`
 	Target                proxy.Config                   `yaml:"target"`
 	PersistedOperations   persisted_operations.Config    `yaml:"persisted_operations"`
 	BlockFieldSuggestions block_field_suggestions.Config `yaml:"block_field_suggestions"`
+	MaxTokens             tokens.Config                  `yaml:"max_tokens"`
 	MaxAliases            aliases.Config                 `yaml:"max_aliases"`
 }
 

--- a/internal/business/aliases/aliases.go
+++ b/internal/business/aliases/aliases.go
@@ -19,7 +19,7 @@ var resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 type Config struct {
 	Enabled         bool `conf:"default:true" yaml:"enabled"`
 	Max             int  `conf:"default:15" yaml:"max"`
-	RejectOnFailure bool `conf:"default:true" yaml:"reject-on-failure"`
+	RejectOnFailure bool `conf:"default:true" yaml:"reject_on_failure"`
 }
 
 func init() {

--- a/internal/business/tokens/tokens.go
+++ b/internal/business/tokens/tokens.go
@@ -19,7 +19,7 @@ var resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 type Config struct {
 	Enabled         bool `conf:"default:true" yaml:"enabled"`
 	Max             int  `conf:"default:1000" yaml:"max"`
-	RejectOnFailure bool `conf:"default:true" yaml:"reject-on-failure"`
+	RejectOnFailure bool `conf:"default:true" yaml:"reject_on_failure"`
 }
 
 type MaxTokensRule struct {


### PR DESCRIPTION
the `max_tokens` config in the yaml was ignored due to incorrect mapping
The same applied to '`reject_on_failure`' boolean for both `max_aliases` and `max_tokens`