### PR TITLE
add 'obfuscate_validation_errors' option to hide details about configured limits

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
 	"github.com/stretchr/testify/assert"
 	"io"
@@ -281,6 +282,66 @@ input ImageInput {
 				assert.NoError(t, err)
 				// perform string comparisons as map[string]interface seems incomparable
 				assert.True(t, errorsContainsMessage("syntax error: Aliases limit of 3 exceeded, found 10", actual))
+			},
+		},
+		{
+			name: "redacts error message of request with too many aliases",
+			args: args{
+				request: func() *http.Request {
+					body := map[string]interface{}{
+						"query": `
+query Foo($image: ImageInput!) { 
+	a1: uploadImage(image: $image)
+	a2: uploadImage(image: $image)
+}`,
+						"variables": map[string]interface{}{
+							"image": map[string]interface{}{
+								"id": "1",
+							},
+						},
+					}
+
+					bts, _ := json.Marshal(body)
+					r := httptest.NewRequest("POST", "/graphql", bytes.NewBuffer(bts))
+					return r
+				}(),
+				schema: `
+extend type Query {
+	uploadImage(image: ImageInput!): String
+}
+
+input ImageInput {
+	id: ID!
+}
+`,
+				cfgOverrides: func(cfg *config.Config) *config.Config {
+					cfg.MaxAliases.Enabled = true
+					cfg.MaxAliases.Max = 1
+					cfg.ObfuscateValidationErrors = true
+					return cfg
+				},
+				mockResponse: map[string]interface{}{
+					"data": map[string]interface{}{
+						"a1": "Yes",
+						"a2": "Yes",
+					},
+				},
+				mockStatusCode: http.StatusOK,
+			},
+			want: func(t *testing.T, response *http.Response) {
+				expected := map[string]interface{}{
+					"errors": []map[string]interface{}{
+						{
+							"message": "Error(s) redacted",
+						},
+					},
+				}
+				_, _ = json.Marshal(expected)
+				actual, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				// perform string comparisons as map[string]interface seems incomparable
+				fmt.Println(string(actual))
+				assert.True(t, errorsContainsMessage("Error(s) redacted", actual))
 			},
 		},
 		{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,10 @@ schema:
     # The interval in which the schema file should be reloaded
     interval: 5m
     
+# Configures whether we obfuscate graphql-armor validation errors such as max_aliases/max_tokens
+# Recommended to set it to 'true' for public environments
+obfuscate_validation_errors: false    
+    
 persisted_operations:
   # Enable or disable the feature, enabled by default
   enabled: true

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -26,12 +26,13 @@ type Config struct {
 		Path string `conf:"default:/graphql" yaml:"path"`
 		//DebugHost       string        `conf:"default:0.0.0.0:4000"`
 	}
-	Schema                schema.Config                  `yaml:"schema"`
-	Target                proxy.Config                   `yaml:"target"`
-	PersistedOperations   persisted_operations.Config    `yaml:"persisted_operations"`
-	BlockFieldSuggestions block_field_suggestions.Config `yaml:"block_field_suggestions"`
-	MaxTokens             tokens.Config                  `yaml:"max_tokens"`
-	MaxAliases            aliases.Config                 `yaml:"max_aliases"`
+	ObfuscateValidationErrors bool                           `conf:"default:false" yaml:"obfuscate_validation_errors"`
+	Schema                    schema.Config                  `yaml:"schema"`
+	Target                    proxy.Config                   `yaml:"target"`
+	PersistedOperations       persisted_operations.Config    `yaml:"persisted_operations"`
+	BlockFieldSuggestions     block_field_suggestions.Config `yaml:"block_field_suggestions"`
+	MaxTokens                 tokens.Config                  `yaml:"max_tokens"`
+	MaxAliases                aliases.Config                 `yaml:"max_aliases"`
 }
 
 func NewConfig(configPath string) (*Config, error) {


### PR DESCRIPTION
introduce option: 'obfuscate_validation_errors' to obfuscate errors

Before: 
```
{
  "data": {},
  "errors": [
    {
      "message": "operation has exceeded maximum tokens. found [8], max [1]"
    }
  ]
}
```

after:
```
{
  "data": {},
  "errors": [
    {
      "message": "Error(s) redacted"
    }
  ]
}
```