### PR TITLE
Add Max Batch Size protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ _This is repository inspired by the great work of the similarly named Javascript
 * [Max Aliases](docs/max_aliases.md)
 * [Max Tokens](docs/max_tokens.md)
 * [Max Depth](docs/max_depth.md)
+* [Max Batch](docs/max_batch.md)
 * [Enforce POST](docs/enforce_post.md)
 * _Max Directives (coming soon)_
 * _Cost Limit (coming soon)_

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -238,9 +238,9 @@ func ValidationRules(schema *schema.Provider, tks *tokens.MaxTokensRule, obfusca
 					continue
 				}
 
-				err = validator.Validate(schema.Get(), query)
-				if err != nil {
-					errs = append(errs, gqlerror.Wrap(err))
+				errList := validator.Validate(schema.Get(), query)
+				if len(errList) > 0 {
+					errs = append(errs, errList...)
 					continue
 				}
 			}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -21,7 +21,7 @@ import (
 func TestHttpServerIntegration(t *testing.T) {
 	type args struct {
 		request        *http.Request
-		mockResponse   map[string]interface{}
+		mockResponse   interface{}
 		mockStatusCode int
 		cfgOverrides   func(cfg *config.Config) *config.Config
 		schema         string
@@ -508,6 +508,68 @@ type Product {
 			},
 		},
 		{
+			name: "batching works",
+			args: args{
+				request: func() *http.Request {
+					body := []map[string]interface{}{
+						{"query": "query Foo($id: ID!) { product(id: $id) { id name } }"},
+						{"query": "query Foo($id: ID!) { product(id: $id) { id name } }"},
+						{"query": "query Foo($id: ID!) { product(id: $id) { id name } }"},
+					}
+
+					bts, _ := json.Marshal(body)
+					r := httptest.NewRequest("POST", "/graphql", bytes.NewBuffer(bts))
+					return r
+				}(),
+				schema: `
+extend type Query {
+	product(id: ID!): Product
+}
+
+type Product {
+	id: ID!
+	name: String
+}
+`,
+				cfgOverrides: func(cfg *config.Config) *config.Config {
+					return cfg
+				},
+				mockResponse: []map[string]interface{}{
+					{
+						"data": map[string]interface{}{
+							"product": map[string]interface{}{
+								"id":   "1",
+								"name": "name",
+							},
+						},
+					},
+					{
+						"data": map[string]interface{}{
+							"product": map[string]interface{}{
+								"id":   "1",
+								"name": "name",
+							},
+						},
+					},
+					{
+						"data": map[string]interface{}{
+							"product": map[string]interface{}{
+								"id":   "1",
+								"name": "name",
+							},
+						},
+					},
+				},
+				mockStatusCode: http.StatusOK,
+			},
+			want: func(t *testing.T, response *http.Response) {
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+				_, err := io.ReadAll(response.Body)
+				assert.NoError(t, err)
+				//assert.Contains(t, string(actual), "operation has exceeded maximum tokens. found [22], max [1]")
+			},
+		},
+		{
 			name: "blocks operations through GET requests",
 			args: args{
 				request: func() *http.Request {
@@ -578,7 +640,11 @@ type Product {
 
 			go func() {
 				err := run(slog.Default(), cfg, shutdown)
-				assert.NoError(t, err, "error starting server for", tt.name)
+				if err != nil {
+					assert.NoError(t, err, "error starting server for", tt.name)
+					t.Fatalf("could not start application server %v", err)
+					return
+				}
 			}()
 
 			start := time.Now()

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ Please see each section for in-depth documentation
 * [Block Field Suggestions](block_field_suggestions.md)
 * [Max Aliases](max_aliases.md)
 * [Max Tokens](max_tokens.md)
-* [Enforce POST](enforce_post)
+* [Enforce POST](enforce_post.md)
+* [Max Batch](max_batch.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,14 @@ max_tokens:
   # Reject the request when the rule fails. Disable this to allow the request regardless of token count.
   reject_on_failure: true
 
+max_batch:
+  # Enable the feature
+  enable: "true"
+  # The maximum number of operations within a single batched request.
+  max: 5
+  # Reject the request when the rule fails. Disable this to allow the request regardless of token count.
+  reject_on_failure: "true"
+
 disable_get_method:
   # Enable the feature
   enable: "true"

--- a/docs/max_batch.md
+++ b/docs/max_batch.md
@@ -1,0 +1,37 @@
+# Max Batch
+
+Restricts the maximum number of operations inside a batched request. This helps prevent an excessive number operations reaching your landscape through minimal requests.
+This can be useful to prevent DDoS attacks, Heap Overflows or Server overload.
+
+<!-- TOC -->
+
+## Configuration
+
+You can configure `go-graphql-armor` to limit the maximum number of operations allowed inside a batch request.
+
+```yaml
+max_batch:
+  # Enable the feature
+  enable: "true"
+  # The maximum number of operations within a single batched request.
+  max: 5
+  # Reject the request when the rule fails. Disable this to allow the request regardless of token count.
+  reject_on_failure: "true"
+```
+
+## Metrics
+
+This rule produces metrics to help you gain insights into the behavior of the rule.
+
+```
+go_graphql_armor_max_batch_results{result}
+```
+
+
+| `result`  | Description                                                                                                  |
+|---------|--------------------------------------------------------------------------------------------------------------|
+| `allowed` | The rule condition succeeded                                                                                 |
+| `rejected` | The rule condition failed and the request was rejected                                                       |
+| `failed` | The rule condition failed but the request was not rejected. This happens when `reject_on_failure` is `false` |
+
+No metrics are produced when the rule is disabled.

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ardanlabs/conf/v3"
 	"github.com/ardanlabs/conf/v3/yaml"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/aliases"
+	"github.com/ldebruijn/go-graphql-armor/internal/business/batch"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/enforce_post"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/max_depth"
@@ -37,6 +38,7 @@ type Config struct {
 	MaxAliases                aliases.Config                 `yaml:"max_aliases"`
 	EnforcePost               enforce_post.Config            `yaml:"enforce_post"`
 	MaxDepth                  max_depth.Config               `yaml:"max_depth"`
+	MaxBatch                  batch.Config                   `yaml:"max_batch"`
 }
 
 func NewConfig(configPath string) (*Config, error) {

--- a/internal/business/batch/batch.go
+++ b/internal/business/batch/batch.go
@@ -1,0 +1,70 @@
+package batch
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/lexer"
+)
+
+var resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "go_graphql_armor",
+	Subsystem: "max_batch",
+	Name:      "results",
+	Help:      "The results of the max batch rule",
+},
+	[]string{"result"},
+)
+
+type Config struct {
+	Enabled         bool `conf:"default:true" yaml:"enabled"`
+	Max             int  `conf:"default:3" yaml:"max"`
+	RejectOnFailure bool `conf:"default:true" yaml:"reject_on_failure"`
+}
+
+func init() {
+	prometheus.MustRegister(resultCounter)
+}
+
+type MaxBatchRule struct {
+	cfg Config
+}
+
+func MaxBatch(cfg Config) *MaxBatchRule {
+	return &MaxBatchRule{
+		cfg: cfg,
+	}
+}
+
+func (t *MaxBatchRule) Validate(source *ast.Source) error {
+	if !t.cfg.Enabled {
+		return nil
+	}
+
+	lex := lexer.New(source)
+	count := 0
+
+	for {
+		tok, err := lex.ReadToken()
+
+		if err != nil {
+			return err
+		}
+
+		if tok.Kind == lexer.EOF {
+			break
+		}
+
+		count++
+	}
+
+	if count > t.cfg.Max {
+		if t.cfg.RejectOnFailure {
+			resultCounter.WithLabelValues("rejected").Inc()
+			return fmt.Errorf("operation has exceeded maximum tokens. found [%d], max [%d]", count, t.cfg.Max)
+		}
+		resultCounter.WithLabelValues("failed").Inc()
+	}
+	resultCounter.WithLabelValues("allowed").Inc()
+	return nil
+}

--- a/internal/business/batch/batch_test.go
+++ b/internal/business/batch/batch_test.go
@@ -1,0 +1,140 @@
+package batch
+
+import (
+	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMaxBatchRule_Validate(t1 *testing.T) {
+	type fields struct {
+		cfg Config
+	}
+	type args struct {
+		payload []gql.RequestData
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		initErr bool
+	}{
+		{
+			name: "disabled has no effect",
+			fields: fields{
+				cfg: Config{
+					Enabled:         false,
+					Max:             1,
+					RejectOnFailure: true,
+				},
+			},
+			args: args{
+				payload: []gql.RequestData{
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+				},
+			},
+			wantErr: false,
+			initErr: false,
+		},
+		{
+			name: "less than limit passes",
+			fields: fields{
+				cfg: Config{
+					Enabled:         true,
+					Max:             3,
+					RejectOnFailure: true,
+				},
+			},
+			args: args{
+				payload: []gql.RequestData{
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+				},
+			},
+			wantErr: false,
+			initErr: false,
+		},
+		{
+			name: "more than limit throws",
+			fields: fields{
+				cfg: Config{
+					Enabled:         true,
+					Max:             1,
+					RejectOnFailure: true,
+				},
+			},
+			args: args{
+				payload: []gql.RequestData{
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+				},
+			},
+			wantErr: true,
+			initErr: false,
+		},
+		{
+			name: "invalid config auto disables",
+			fields: fields{
+				cfg: Config{
+					Enabled:         true,
+					Max:             0,
+					RejectOnFailure: true,
+				},
+			},
+			args: args{
+				payload: []gql.RequestData{
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+					{
+						Query:      "",
+						Extensions: gql.Extensions{},
+					},
+				},
+			},
+			wantErr: false,
+			initErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t, err := NewMaxBatch(tt.fields.cfg)
+			if tt.initErr {
+				assert.Error(t1, err)
+			}
+
+			if err := t.Validate(tt.args.payload); (err != nil) != tt.wantErr {
+				t1.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/business/gql/gql.go
+++ b/internal/business/gql/gql.go
@@ -8,13 +8,13 @@ import (
 )
 
 type RequestData struct {
-	Variables  map[string]interface{} `json:"variables"`
-	Query      string                 `json:"query"`
-	Extensions Extensions             `json:"extensions"`
+	Variables  map[string]interface{} `json:"variables,omitempty"`
+	Query      string                 `json:"query,omitempty"`
+	Extensions Extensions             `json:"extensions,omitempty"`
 }
 
 type Extensions struct {
-	PersistedQuery *PersistedQuery `json:"persistedQuery"`
+	PersistedQuery *PersistedQuery `json:"persistedQuery,omitempty"`
 }
 
 type PersistedQuery struct {

--- a/internal/business/gql/gql_test.go
+++ b/internal/business/gql/gql_test.go
@@ -1,0 +1,147 @@
+package gql
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestParseRequestPayload(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []RequestData
+		wantErr bool
+	}{
+		{
+			name: "parses regular operation correctly",
+			args: args{
+				r: func() *http.Request {
+					payload := `
+{
+	"query": "something",
+	"variables": {
+		"baz": "foobar"	
+	},
+	"extensions": {
+		"foo": "bar"	
+	}
+}
+`
+					body := bytes.NewBuffer([]byte(payload))
+					return httptest.NewRequest("POST", "/graphql", body)
+				}(),
+			},
+			want: []RequestData{
+				{
+					Variables: map[string]interface{}{
+						"baz": "foobar",
+					},
+					Query:      "something",
+					Extensions: Extensions{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "parses batched operation correctly",
+			args: args{
+				r: func() *http.Request {
+					payload := `
+[
+{
+	"query": "query batched 1",
+	"variables": {
+		"baz": "variables batched 1"	
+	},
+	"extensions": {
+		"foo": "extension batched 1"	
+	}
+},
+{
+	"query": "query batched 2",
+	"variables": {
+		"baz": "variables batched 2"	
+	},
+	"extensions": {
+		"foo": "extensions batched 2"	
+	}
+}
+]
+`
+					body := bytes.NewBuffer([]byte(payload))
+					return httptest.NewRequest("POST", "/graphql", body)
+				}(),
+			},
+			want: []RequestData{
+				{
+					Variables: map[string]interface{}{
+						"baz": "variables batched 1",
+					},
+					Query:      "query batched 1",
+					Extensions: Extensions{},
+				},
+				{
+					Variables: map[string]interface{}{
+						"baz": "variables batched 2",
+					},
+					Query:      "query batched 2",
+					Extensions: Extensions{},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRequestPayload(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRequestPayload() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseRequestPayload() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkCheckJSONType(b *testing.B) {
+	// Create a sample JSON object
+	jsonObject := []byte(`{
+	"query": "something",
+	"variables": {
+		"baz": "foobar"	
+	},
+	"extensions": {
+		"foo": "bar"	
+	}
+},`)
+
+	// Create a sample JSON array
+	jsonArray := []byte(fmt.Sprintf("[%[1]s, %[1]s, %[1]s, %[1]s, %[1]s]", jsonObject))
+
+	for i := 0; i < b.N; i++ {
+		// Benchmark decoding a JSON object
+		b.Run("JSON Object", func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				r := httptest.NewRequest("POST", "/graphql", bytes.NewBuffer(jsonObject))
+				_, _ = ParseRequestPayload(r)
+			}
+		})
+
+		// Benchmark decoding a JSON array
+		b.Run("JSON Array", func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				r := httptest.NewRequest("POST", "/graphql", bytes.NewBuffer(jsonArray))
+				_, _ = ParseRequestPayload(r)
+			}
+		})
+	}
+}

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -142,7 +142,7 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 
 // Execute runs of the persisted operations handler
 // it uses the configuration supplied to decide its behavior
-func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler { // nolint:funlen
+func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler { // nolint:funlen,cyclop
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if !p.cfg.Enabled || r.Method != "POST" {
 			next.ServeHTTP(w, r)

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -1,10 +1,12 @@
 package persisted_operations // nolint:revive
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,7 +15,6 @@ import (
 )
 
 import (
-	"bytes"
 	"context"
 )
 
@@ -37,9 +38,11 @@ var (
 )
 
 type ErrorPayload struct {
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+	Errors gqlerror.List `json:"errors"`
+}
+
+type ErrorMessage struct {
+	Message string `json:"message"`
 }
 
 type Config struct {
@@ -61,6 +64,8 @@ type Config struct {
 
 var ErrNoLoaderSupplied = errors.New("no remoteLoader supplied")
 var ErrNoHashFound = errors.New("no hash found")
+var ErrPersistedQueryNotFound = errors.New("PersistedQueryNotFound")
+var ErrPersistedOperationNotFound = errors.New("PersistedOperationNotFound")
 var ErrReloadIntervalTooShort = errors.New("reload interval cannot be less than 10 seconds")
 
 type PersistedOperationsHandler struct {
@@ -144,6 +149,8 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler { /
 			return
 		}
 
+		var errs gqlerror.List
+
 		payload, err := gql.ParseRequestPayload(r)
 		if err != nil {
 			p.log.Warn("error decoding payload", "err", err)
@@ -151,50 +158,68 @@ func (p *PersistedOperationsHandler) Execute(next http.Handler) http.Handler { /
 			return
 		}
 
-		if !p.cfg.FailUnknownOperations && payload.Query != "" {
-			persistedOpsCounter.WithLabelValues("unknown", "allowed").Inc()
-			next.ServeHTTP(w, r)
-			return
+		for i, data := range payload {
+			if !p.cfg.FailUnknownOperations && data.Query != "" {
+				persistedOpsCounter.WithLabelValues("unknown", "allowed").Inc()
+				continue
+			}
+
+			hash, err := hashFromPayload(data)
+			if err != nil {
+				persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
+				errs = append(errs, gqlerror.Wrap(ErrPersistedQueryNotFound))
+				continue
+			}
+
+			p.lock.RLock()
+			query, ok := p.cache[hash]
+			p.lock.RUnlock()
+
+			if !ok {
+				// hash not found, fail
+				persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
+				errs = append(errs, gqlerror.Wrap(ErrPersistedOperationNotFound))
+				continue
+			}
+
+			// update the original data
+			payload[i].Query = query
+			payload[i].Extensions.PersistedQuery = nil
+
+			persistedOpsCounter.WithLabelValues("known", "allowed").Inc()
 		}
 
-		hash, err := hashFromPayload(payload)
-		if err != nil {
-			persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
-			p.log.Warn("no hash found ", "err", err)
-			res, _ := json.Marshal(buildErrorResponse("PersistedQueryNotFound"))
+		if len(errs) > 0 {
+			// if any error occured we fail
+			res, _ := json.Marshal(ErrorPayload{
+				Errors: errs,
+			})
 			http.Error(w, string(res), 200)
 			return
 		}
 
-		p.lock.RLock()
-		query, ok := p.cache[hash]
-		p.lock.RUnlock()
-
-		if !ok {
-			// hash not found, fail
-			persistedOpsCounter.WithLabelValues("unknown", "rejected").Inc()
-			p.log.Warn("Unknown hash, persisted operation not found ", "hash", hash)
-			res, _ := json.Marshal(buildErrorResponse("PersistedOperationNotFound"))
-			http.Error(w, string(res), 200)
-			return
-		}
-
-		payload.Query = query
-		payload.Extensions.PersistedQuery = nil
-
-		bts, err := json.Marshal(payload)
-		if err != nil {
-			// handle
-			persistedOpsCounter.WithLabelValues("errored", "allowed").Inc()
-			next.ServeHTTP(w, r)
-			return
+		var bts []byte
+		// forward batched request
+		if len(payload) > 1 {
+			bts, err = json.Marshal(payload)
+			if err != nil {
+				// handle
+				next.ServeHTTP(w, r)
+				return
+			}
+		} else if len(payload) == 1 {
+			// forward regular request
+			bts, err = json.Marshal(payload[0])
+			if err != nil {
+				// handle
+				next.ServeHTTP(w, r)
+				return
+			}
 		}
 
 		// overwrite request body with new payload
 		r.Body = io.NopCloser(bytes.NewBuffer(bts))
 		r.ContentLength = int64(len(bts))
-
-		persistedOpsCounter.WithLabelValues("known", "allowed").Inc()
 
 		next.ServeHTTP(w, r)
 	}
@@ -262,7 +287,7 @@ func (p *PersistedOperationsHandler) Shutdown() {
 	p.done <- true
 }
 
-func hashFromPayload(payload gql.RequestPayload) (string, error) {
+func hashFromPayload(payload gql.RequestData) (string, error) {
 	if payload.Extensions.PersistedQuery == nil {
 		return "", ErrNoHashFound
 	}
@@ -273,18 +298,4 @@ func hashFromPayload(payload gql.RequestPayload) (string, error) {
 	}
 
 	return hash, nil
-}
-
-func buildErrorResponse(message string) ErrorPayload {
-	return ErrorPayload{
-		Errors: []struct {
-			Message string `json:"message"`
-		}([]struct {
-			Message string
-		}{
-			{
-				Message: message,
-			},
-		}),
-	}
 }

--- a/internal/business/persisted_operations/persisted_operations_test.go
+++ b/internal/business/persisted_operations/persisted_operations_test.go
@@ -141,11 +141,11 @@ func TestNewPersistedOperations(t *testing.T) {
 					assert.NoError(t, err)
 
 					assert.Equal(t, "query { foobar }", payload.Query)
-					assert.Equal(t, int64(82), r.ContentLength)
+					assert.Equal(t, int64(44), r.ContentLength)
 
 					length, _ := json.Marshal(payload)
 
-					assert.Equal(t, 82, len(length))
+					assert.Equal(t, 44, len(length))
 				}
 				return http.HandlerFunc(fn)
 			},
@@ -190,7 +190,7 @@ func TestNewPersistedOperations(t *testing.T) {
 					payload, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
 
-					assert.Equal(t, `[{"variables":null,"query":"query { foobar }","extensions":{"persistedQuery":null}},{"variables":null,"query":"query { baz }","extensions":{"persistedQuery":null}}]`, string(payload))
+					assert.Equal(t, `[{"query":"query { foobar }","extensions":{}},{"query":"query { baz }","extensions":{}}]`, string(payload))
 					assert.Equal(t, int64(len(payload)), r.ContentLength)
 				}
 				return http.HandlerFunc(fn)


### PR DESCRIPTION
Resolves #37 

Adds support for batched operations, and includes a protection to limit the number of operations allowed inside a single batched request.