### PR TITLE
feat: Change metrics for specific rules to histograms, rename option …

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,17 +38,10 @@ import (
 )
 
 var (
-	shortHash   = "develop"
-	build       = "develop"
-	configPath  = ""
-	httpCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "go_graphql_armor",
-		Subsystem: "http",
-		Name:      "count",
-		Help:      "HTTP request counts",
-	},
-		[]string{"route"},
-	)
+	shortHash  = "develop"
+	build      = "develop"
+	configPath = ""
+
 	httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "go_graphql_armor",
 		Subsystem: "http",
@@ -70,7 +63,7 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(httpCounter, httpDuration, appInfo)
+	prometheus.MustRegister(httpDuration, appInfo)
 }
 
 func main() {
@@ -242,7 +235,7 @@ func ValidationRules(schema *schema.Provider, tks *tokens.MaxTokensRule, batch *
 					err = tks.Validate(operationSource)
 					if err != nil {
 						errs = append(errs, gqlerror.Wrap(err))
-						continue
+						continue // we could consider break-ing here. That would short-circuit on error, with the downside of not returning all potential errors
 					}
 
 					var query, err = parser.ParseQuery(operationSource)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -169,7 +169,7 @@ type Product {
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
 					cfg.PersistedOperations.Store = "./"
-					cfg.PersistedOperations.FailUnknownOperations = false
+					cfg.PersistedOperations.RejectOnFailure = false
 					return cfg
 				},
 				mockResponse: map[string]interface{}{
@@ -369,7 +369,7 @@ type Product {
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
 					cfg.PersistedOperations.Store = "./"
-					cfg.PersistedOperations.FailUnknownOperations = false
+					cfg.PersistedOperations.RejectOnFailure = false
 					return cfg
 				},
 				mockResponse: map[string]interface{}{
@@ -433,7 +433,7 @@ type Product {
 				cfgOverrides: func(cfg *config.Config) *config.Config {
 					cfg.PersistedOperations.Enabled = true
 					cfg.PersistedOperations.Store = "./"
-					cfg.PersistedOperations.FailUnknownOperations = false
+					cfg.PersistedOperations.RejectOnFailure = false
 					return cfg
 				},
 				mockResponse: map[string]interface{}{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ persisted_operations:
   # Enable or disable the feature, enabled by default
   enabled: true
   # Fail unknown operations, disable this feature to allow unknown operations to reach your GraphQL API
-  fail_unknown_operations: true
+  reject_on_failure: true
   # Store is the location on local disk where go-graphql-armor can find the persisted operations, it loads any `*.json` files on disk
   store: "./store"
   reload:

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -19,7 +19,7 @@ persisted_operations:
   # Enable or disable the feature, enabled by default
   enabled: "true"
   # Fail unknown operations, disable this feature to allow unknown operations to reach your GraphQL API
-  fail_unknown_operations: "true"
+  reject_on_failure: "true"
   # Store is the location on local disk where go-graphql-armor can find the persisted operations, it loads any `*.json` files on disk
   store: "./store"
   reload:
@@ -88,10 +88,10 @@ This rule produces metrics to help you gain insights into the behavior of the ru
 go_graphql_armor_persisted_operations_results{state, result}
 ```
 
-| `state`    | Description                                                                                                                                                   |
-|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `unknown`   | The rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request. |
-| `errored` | The rule caught an error during request body mutation.                                                                                                        |
+| `state`  | Description                                                                                                                                                   |
+|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `unknown` | The rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request. |
+| `error` | The rule caught an error during request body mutation.                                                                                                        |
 | `known` | The rule received a hash for which it had a known operation                                                                                                   |
 
 

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -90,7 +90,7 @@ go_graphql_armor_persisted_operations_results{state, result}
 
 | `state`  | Description                                                                                                                                                   |
 |---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `unknown` | The rule was not able to do its job. This happens either when `fail_unknown_operations` is set to `false` or the rule was not able to deserialize the request. |
+| `unknown` | The rule was not able to do its job. This happens either when `reject_on_failure` is set to `false` or the rule was not able to deserialize the request. |
 | `error` | The rule caught an error during request body mutation.                                                                                                        |
 | `known` | The rule received a hash for which it had a known operation                                                                                                   |
 

--- a/internal/business/persisted_operations/persisted_operations_test.go
+++ b/internal/business/persisted_operations/persisted_operations_test.go
@@ -44,8 +44,8 @@ func TestNewPersistedOperations(t *testing.T) {
 			name: "Allows unpersisted requests if configured",
 			args: args{
 				cfg: Config{
-					Enabled:               true,
-					FailUnknownOperations: true,
+					Enabled:         true,
+					RejectOnFailure: true,
 				},
 				payload: func() []byte {
 					data := gql.RequestData{
@@ -75,8 +75,8 @@ func TestNewPersistedOperations(t *testing.T) {
 			name: "Returns error if no hash match is found and unpersisted operations are not allowed",
 			args: args{
 				cfg: Config{
-					Enabled:               true,
-					FailUnknownOperations: false,
+					Enabled:         true,
+					RejectOnFailure: false,
 				},
 				payload: func() []byte {
 					data := gql.RequestData{
@@ -114,8 +114,8 @@ func TestNewPersistedOperations(t *testing.T) {
 			name: "Swaps in query payload if hash operation is known, updates content length accordingly",
 			args: args{
 				cfg: Config{
-					Enabled:               true,
-					FailUnknownOperations: false,
+					Enabled:         true,
+					RejectOnFailure: false,
 				},
 				payload: func() []byte {
 					data := gql.RequestData{
@@ -157,8 +157,8 @@ func TestNewPersistedOperations(t *testing.T) {
 			name: "Swaps in batched query payload if hash operation is known, updates content length accordingly",
 			args: args{
 				cfg: Config{
-					Enabled:               true,
-					FailUnknownOperations: false,
+					Enabled:         true,
+					RejectOnFailure: false,
 				},
 				payload: func() []byte {
 					data := []gql.RequestData{
@@ -203,8 +203,8 @@ func TestNewPersistedOperations(t *testing.T) {
 			name: "fails entire batch if one operation is unknown",
 			args: args{
 				cfg: Config{
-					Enabled:               true,
-					FailUnknownOperations: false,
+					Enabled:         true,
+					RejectOnFailure: false,
 				},
 				payload: func() []byte {
 					data := []gql.RequestData{

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,7348 @@
+directive @ContainerSize(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.ContainerSize.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+"""The different types of AccountPages"""
+enum AccountPage {
+    """Orders Account Pages Type"""
+    ORDERS
+}
+
+"""Ad context used by google ad manager to generate targeted ads"""
+type AdContext {
+    """Network code used internally by google ad manager"""
+    adNetworkCode: String!
+    """Similar to slot code, used internally by google ad manager"""
+    adPositionId: String!
+    """Similar to a page breadcrumb, used internally by google ad manager"""
+    adUnitHierarchy: String
+    """
+    List of key-value pairs that are used to target ads. An important key is 'audiences' which is used to target ads based on user segments
+    """
+    adTargetingValues: [AdTarget!]!
+    """
+    List of screen dimensions that acts as hints to know the screen size of the device the ad is being rendered on
+    """
+    adScreenDimensions: [AdScreenDimension]
+}
+
+"""Ad context input"""
+input AdContextInput {
+    """Page type the ad is being rendered on"""
+    pageType: AdPageType!
+    """Slot codes on the page the AD will be placed on"""
+    slotCodes: [String!]!
+    """List of category ID(s) to get the Ad context for"""
+    categories: [String]
+    """Global ID to get the Ad context for"""
+    globalId: String
+    """List context to get the Ad context for"""
+    listContext: String
+    """Section to get the Ad context for"""
+    section: String
+    """List of test variants"""
+    testVariants: [String]
+    """Search term to get the Ad context for"""
+    searchTerm: String
+}
+
+"""The surface area of the ad"""
+type AdDimension {
+    """Width of the ad measured in pixels"""
+    width: Int!
+    """Height of the ad measured in pixels"""
+    height: Int!
+}
+
+input AddItemToLastUsedWishlistInput {
+    """ID of the product to add to the wishlist"""
+    productId: ID!
+    """Determines how the wishlist in the response are sorted"""
+    sortedBy: WishlistSortOption! = MUTATION_DESC
+}
+
+union AddItemToLastUsedWishlistResult = WishlistOverview | InvalidUserProblem | NoWishlistFoundForCustomerProblem | MaxItemsPerWishListLimitReachedProblem
+
+"""Allowed page types for ads to be rendered on"""
+enum AdPageType {
+    PDP
+    CMS
+    LPSEARCH
+    LPBROWSE
+    LPBRAND
+    LPSELLER
+    LPCREATOR
+    LPRETAILACTION
+    LPSERIE
+    OCP
+    MHP
+}
+
+type AdScreenDimension {
+    """Screen size of the device the ad is being rendered on"""
+    screenSize: AdScreenSize!
+    """List of ad dimensions that are used to target ads"""
+    adDimension: [AdDimension!]!
+}
+
+"""Screen size of the device the ad is being rendered on"""
+enum AdScreenSize {
+    XSMALL
+    SMALL
+    MEDIUM
+    LARGE
+    XLARGE
+}
+
+type AdTarget {
+    """Key used to target ads"""
+    key: String!
+    """List of values used to target ads"""
+    value: [String!]!
+}
+
+type AdTransparency {
+    """The advertiser on whose behalf the ad is presented"""
+    beneficiary: Advertiser!
+    """The advertiser who is paying for the ad"""
+    payer: Advertiser!
+}
+
+"""Partner responsible for advertisements"""
+type Advertiser {
+    """Advertiser ID"""
+    id: ID!
+    """Name of the advertiser"""
+    name: String!
+}
+
+"""
+Allocation(Associated range for different variants). for more info check out this document: https://docs.bol.io/experimentation-cookbook/in-depth/verifying.html#forcing_a_variant_visual
+"""
+type Allocation {
+    """Start number of the range for the variant."""
+    start: Int!
+    """End number of the range for the variant."""
+    end: Int!
+}
+
+type AnonymousCustomer implements Customer {
+    notUsed: Boolean! @deprecated(reason: "Do not use this field")
+    recentlyViewed: ProductConnection
+    favoriteShelves: ProductCategoryConnection
+    productCategories: ProductCategoryConnection
+    """Deals grouped by brand"""
+    brandDeals: [BrandDeals!]
+    """
+    Returns Top Deals (Promotional feed) with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    promotionalFeed: ProductConnection
+    """
+    Returns New for You with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    newForYou: ProductConnection
+    """
+    Returns Top Picks with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    topPicks: ProductConnection
+    """
+    Returns Brands with list of personalized brand items per unique customer (if logged in/ recognised and consent given, else fallback popular brand items)
+    """
+    favoriteBrands: BrandConnection @deprecated(reason: "Use brandsDeals query instead")
+}
+
+"""Contains the asset metadata with a list of renditions."""
+type Asset {
+    """The unique identifier of the asset."""
+    id: ID!
+    """The order of the asset within the publication."""
+    order: Int!
+    """The most dominant color of the asset, in HSL format."""
+    dominantColor: AssetColor!
+    """
+    The list of renditions for the asset. The preset field filters renditions based on the given preset value. If not specified, it shows all renditions available for the asset. For more information on available renditions, visit https://docs.bol.io/fox/asset-lifecycle/rendering.html#_available_renditions
+    """
+    renditions(preset: [String!]): [AssetRendition!]!
+    """The media type of the asset."""
+    mediaType: AssetMediaType!
+    """
+    The labels array contains the asset labels. Labels can be used to identify specific assets, such as SWATCH, BACK COVER.
+    """
+    labels: [String!]
+}
+
+"""The color properties for an asset."""
+type AssetColor {
+    """The hue component of the color (0-360 degrees)."""
+    hue: Int!
+    """The saturation component of the color (0-100%)."""
+    saturation: Int!
+    """The lightness component of the color (0-100%)."""
+    lightness: Int!
+    """The percentage of color coverage in the asset."""
+    percentage: Float!
+}
+
+"""The supported media types for an asset."""
+enum AssetMediaType {
+    IMAGE
+    VIDEO
+    PDF
+}
+
+"""
+Contains a list of published assets, for a given reference type and reference ID.
+"""
+type AssetPublication {
+    """
+    The referenceType field represents the type of reference and can take values such as global_id, retailer_id, etc.
+    """
+    referenceType: String!
+    """The unique identifier of the reference."""
+    referenceId: ID!
+    """Variant name used for AB experiments, for example 'default'."""
+    variant: String!
+    """The time the asset publication was created / updated."""
+    updatedAt: DateTime!
+    """
+    The list of assets in the publication. The mediaType field filters assets based on specific media types. If not explicitly mentioned, it shows all assets. The limit parameter can be used to restrict the number of returned assets.
+    """
+    assets(mediaType: [AssetMediaType!], limit: Int): [Asset!]!
+}
+
+"""An individual asset rendition, with metadata and a URL."""
+type AssetRendition {
+    """Name of the rendition, for example 'large'."""
+    preset: String!
+    """
+    The width of the rendition. Can be nullable for certain assets, such as PDFs.
+    """
+    width: Int
+    """
+    The height of the rendition. Can be nullable for certain assets, such as PDFs.
+    """
+    height: Int
+    """The MIME type of the asset, such as image/jpeg."""
+    mimeType: String!
+    """The URL of the asset rendition."""
+    url: String!
+    """The compression quality for JPEG assets."""
+    quality: Int
+}
+
+"""A banner that can be shown to customers"""
+type Banner {
+    """Measurements for this banner."""
+    measurements: BannerMeasurements!
+    """
+    A priority number, that defines in what order this banner should be shown.
+    """
+    priority: Int!
+    """The caption for this banner."""
+    caption: BannerCaption!
+    """The URL resource for the asset."""
+    imageUrl: String!
+    """The alt text that should be shown for the asset."""
+    imageAltText: String
+    """The target URL for the banner."""
+    targetUrl: String!
+    """
+    This indicates if it is a special campaign. If true then the banner comes from Contentstack AND the image already contains all the necessary elements (e.g. title, sub title, button, etc) so FE should not add them
+    """
+    isSpecialCampaign: Boolean!
+    """Information about the party behind an ad"""
+    adTransparency: AdTransparency
+    """The beneficiary of the advertisement"""
+    beneficiaryAdvertiserId: String
+    """The payer of the advertisement"""
+    payerAdvertiserId: String
+}
+
+"""Caption used for a banner."""
+type BannerCaption {
+    """The title for the caption."""
+    title: String!
+    """The subtitle for the caption."""
+    subTitle: String
+    """
+    The color for the subtitle. If present, it should override `textColor`.
+    """
+    subTitleColor: String
+    """A possible disclaimer for this banner."""
+    disclaimerText: String
+    """
+    The textcolor for the main title and subtitle (unless specified otherwise in the `subTitleColor`.
+    """
+    textColor: String
+    """Color for the background of the caption."""
+    backgroundColor: String
+    """The button text"""
+    buttonText: String
+    """Variant of the call to action."""
+    callToActionVariant: String
+}
+
+"""
+Entry of content type BANNER_CARROUSEL_APP. Contains data needed to render banner carrousel in app.
+"""
+type BannerCarrouselApp implements EntryResponse {
+    """The locale the content of this entry is in, coming from CMS."""
+    language: String!
+    """Name of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+    """
+    Carrousel app items. Order in the list determines the order of display in app.
+    """
+    items: [BannerCarrouselAppItem]
+}
+
+"""
+Entry of content type BANNER_CARROUSEL_APP_ITEM. Represents a banner in app carrousel.
+"""
+type BannerCarrouselAppItem {
+    """The locale the content of this entry is in, coming from CMS."""
+    language: String!
+    """Name of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+    """Start datetime for the banner"""
+    startDate: DateTime!
+    """Start datetime for the banner"""
+    endDate: DateTime!
+    """Text of the banner"""
+    text: String!
+    """Text color of the banner"""
+    textColor: String!
+    """Banner image url"""
+    imageUrl: String!
+    """Landing page url"""
+    landingPageUrl: String!
+    """Promo code"""
+    promoCode: String
+}
+
+type BannerDeal implements Deal {
+    """The title of the `Deal`."""
+    title: String!
+    """The title of the `Deal` with Markup language."""
+    markupTitle: String!
+    """The subtitle of the `Deal`."""
+    subtitle: String!
+    """Product reference, intended for showing product information only."""
+    highlightedProduct: Product
+    """The DateTime when the `Deal` ends."""
+    expiresAt: DateTime!
+    """The promoParameter for the link of the `Deal`."""
+    promoParameter: String!
+    """ACM Disclaimer for the `Deal`."""
+    disclaimer: String
+    """The type of the `Deal`"""
+    type: DealType!
+    """The url target of this `Deal`."""
+    url: String
+}
+
+type BannerHash {
+    """Used for generating Hero Banner M2 measurements"""
+    hero: String!
+    """Used for generating Flex Banner M2 measurements"""
+    flex: [String!]!
+}
+
+"""A collection of banner-specific measurements."""
+type BannerMeasurements {
+    """Variant of the algorithm."""
+    algorithmVariant: String!
+    """Promo code for the banner."""
+    promoCode: String!
+}
+
+"""Type of the banner promotion"""
+enum BannerMeasurementsPromoType {
+    TOP_BANNER
+    FLEX_BANNER
+}
+
+"""A type of page for the shop."""
+enum BannerPageType {
+    HOME
+}
+
+"""A wrapper containing the banners"""
+type Banners {
+    """Used for generating Banner M2 measurements"""
+    hash: BannerHash
+    """Input argument"""
+    pageType: String!
+    """Input argument"""
+    deviceType: String!
+    """The hero banner (also known as 'main' or 'top' banner)"""
+    hero: Banner
+    """A list of flex banners."""
+    flex(
+        """The amount of flex banners to request."""
+        limit: Int!
+    ): [Banner!]
+}
+
+"""Type representing a shopping basket."""
+type Basket {
+    """Unique identifier for the basket."""
+    id: ID!
+    """Shop context associated with the basket."""
+    shopContext: String!
+    """Customer's person ID associated with the basket."""
+    customerPersonId: String
+    """List of items in the basket."""
+    items: [BasketItem!]!
+    """List of services in the basket."""
+    services: [BasketService!]!
+    """List of subscriptions in the basket."""
+    subscriptions: [BasketSubscription!]!
+    """List of subscription discounts in the basket."""
+    subscriptionDiscounts: [BasketSubscriptionDiscount!]!
+    """List of item discounts in the basket."""
+    itemDiscounts: [BasketItemDiscount!]!
+    """List of coupons in the basket."""
+    coupons: [BasketCoupon!]!
+    """List of subscription usages in the basket."""
+    subscriptionUsages: [BasketSubscriptionUsage!]!
+    """Total quantity of items in the basket."""
+    quantity: Int!
+    """Totals summary for the basket."""
+    totals: BasketTotals
+}
+
+"""Input for adding a coupon to a basket."""
+input BasketAddCouponInput {
+    """ID of the basket to add the coupon to."""
+    basketId: ID!
+    """Coupon code to add to the basket."""
+    couponCode: String!
+}
+
+"""Input for adding a new item to a basket."""
+input BasketAddItemInput {
+    """ID of the basket to add the item to."""
+    basketId: ID!
+    """ID of the product for the new item."""
+    productId: ID!
+    """ID of the retailer offer for the new item."""
+    retailerOfferId: ID!
+    """Quantity of the new item to add."""
+    quantity: Int!
+    """
+    Flag indicating whether to merge quantities if the item already exists.
+    """
+    mergeQuantity: Boolean! = false
+}
+
+"""Input for adding a service to a basket."""
+input BasketAddServiceInput {
+    """ID of the basket to add the service to."""
+    basketId: ID!
+    """ID of the target item for the service."""
+    targetItemId: ID!
+    """ID of the product for the service."""
+    productId: ID!
+}
+
+"""Input for adding a subscription to a basket."""
+input BasketAddSubscriptionInput {
+    """ID of the basket to add the subscription to."""
+    basketId: ID!
+    """ID of the subscription product to add."""
+    subscriptionProductId: ID!
+}
+
+"""Type representing a monetary amount in a basket."""
+type BasketAmount {
+    """Value of the monetary amount."""
+    value: BasketMoney!
+}
+
+"""Type representing a coupon in a basket."""
+type BasketCoupon {
+    """Unique identifier for the coupon."""
+    id: ID!
+    """Code associated with the coupon."""
+    code: String!
+    """Promotion ID associated with the coupon."""
+    promotionId: String
+    """Target for the coupon discount."""
+    target: BasketDiscountTarget
+}
+
+"""Type representing details for digital gift certificates in a basket."""
+type BasketDigitalGiftCertificateDetails {
+    """Theme of the digital gift certificate."""
+    theme: String!
+    """Message associated with the digital gift certificate."""
+    message: String!
+    """Date when the digital gift certificate is scheduled to be sent."""
+    sendDate: String!
+    """Amount associated with the digital gift certificate."""
+    amount: String!
+    """Sender's name for the digital gift certificate."""
+    senderName: String
+    """Sender's email for the digital gift certificate."""
+    senderEmail: String
+    """List of recipients for the digital gift certificate."""
+    recipients: [BasketRecipient!]!
+}
+
+"""Type representing a target for a discount in a basket."""
+type BasketDiscountTarget {
+    """Type of the discount target (ITEM or SUBSCRIPTION)."""
+    type: BasketDiscountTargetType!
+    """Reference value for the discount target."""
+    reference: String!
+}
+
+"""Enum representing the type of discount target in a basket."""
+enum BasketDiscountTargetType {
+    ITEM
+    SUBSCRIPTION
+}
+
+"""Type representing an item in a shopping basket."""
+type BasketItem {
+    """Unique identifier for the basket item."""
+    id: ID!
+    """The product associated with the basket item."""
+    product: Product!
+    """The offer associated with the basket item."""
+    offer: Offer!
+    """The retailer associated with the basket item."""
+    retailer: Retailer!
+    """The quantity of the product in the basket."""
+    quantity: Int!
+    """The price of the basket item."""
+    price: BasketAmount!
+    """
+    The type of price for the basket item (e.g., DEFAULT, MULTIBUNDLE, SELECT).
+    """
+    priceType: BasketPriceType!
+    """Details for digital gift certificates (if applicable)."""
+    digitalGiftCertificateDetails: BasketDigitalGiftCertificateDetails
+    """References to service targets associated with the basket item."""
+    serviceTargets: [BasketServiceTargetReference!]!
+}
+
+"""Type representing a discount associated with an item in a basket."""
+type BasketItemDiscount {
+    """Unique identifier for the item discount."""
+    id: ID!
+    """Promotion ID associated with the item discount."""
+    caPromotionId: ID!
+    """Amount of the item discount."""
+    amount: BasketAmount!
+    """Description of the item discount."""
+    description: String!
+    """List of item discount targets."""
+    targets: [BasketItemDiscountTarget!]!
+    """Coupon target associated with the item discount."""
+    couponTarget: String
+}
+
+"""Type representing a target for an item discount in a basket."""
+type BasketItemDiscountTarget {
+    """Reference value for the item discount target."""
+    reference: String
+}
+
+"""Input for merging two baskets."""
+input BasketMergeInput {
+    """ID of the basket to merge from."""
+    basketIdFrom: ID!
+    """ID of the basket to merge to."""
+    basketIdTo: ID!
+}
+
+"""
+Type representing a message, typically used for notifications or alerts.
+"""
+type BasketMessage {
+    """A unique key identifying the message."""
+    key: String!
+    """The actual text content of the message."""
+    text: String!
+    """The type or category of the message, such as INFO or ERROR."""
+    type: BasketMessageType!
+    """The target entity or context for the message."""
+    target: BasketMessageTarget
+}
+
+"""Mutation operations for basket-messages-related actions."""
+type BasketMessageMutations {
+    """Remove all messages associated with a specific resource."""
+    remove(resourceId: ID!, resourceType: BasketMessageResourceTypeInput!): Boolean
+}
+
+"""Enum defining the types of resources a message can relate to."""
+enum BasketMessageResourceTypeInput {
+    ACTION
+    TRACE
+    BASKET
+}
+
+"""
+Type representing the target of a message, specifying where or to what the message applies.
+"""
+type BasketMessageTarget {
+    """The type of target for the message, such as a basket or an item."""
+    type: BasketMessageTargetType!
+    """A reference identifier for the target."""
+    reference: String!
+}
+
+"""Enum defining possible target types for a message."""
+enum BasketMessageTargetType {
+    BASKET
+    ITEM
+    SUBSCRIPTION
+    SERVICE
+    COUPON
+    DISCOUNT
+}
+
+"""Enum defining various categories of messages."""
+enum BasketMessageType {
+    INFO
+    WARNING
+    ERROR
+    EMERGENCY
+}
+
+"""Type representing a monetary value in a basket."""
+type BasketMoney {
+    """Numeric amount of the money."""
+    amount: String!
+    """Currency of the money."""
+    currency: String!
+}
+
+"""Mutation operations for basket-related actions."""
+type BasketMutations {
+    """Create a new basket."""
+    create: Basket
+    """Merge two baskets based on their IDs."""
+    merge(input: BasketMergeInput!): Basket
+    """Update the shop context for a specific basket."""
+    updateShopContext(input: BasketUpdateShopContextInput!): Basket
+    """Add a new item to a basket."""
+    addItem(input: BasketAddItemInput!): Basket
+    """Remove an item from a basket."""
+    removeItem(input: BasketRemoveItemInput!): Basket
+    """Update the quantity of an item in a basket."""
+    updateItemQuantity(input: BasketUpdateItemQuantityInput!): Basket
+    """Add a subscription to a basket."""
+    addSubscription(input: BasketAddSubscriptionInput!): Basket
+    """Remove a subscription from a basket."""
+    removeSubscription(input: BasketRemoveSubscriptionInput!): Basket
+    """Add a service to a basket."""
+    addService(input: BasketAddServiceInput!): Basket
+    """Remove a service from a basket."""
+    removeService(input: BasketRemoveServiceInput!): Basket
+    """Add a coupon to a basket."""
+    addCoupon(input: BasketAddCouponInput!): Basket
+    """Remove a coupon from a basket."""
+    removeCoupon(input: BasketRemoveCouponInput!): Basket
+    """Update education information for a basket."""
+    updateEducation(input: BasketUpdateEducationInput!): Basket
+    """Remove education information from a basket."""
+    removeEducation(input: BasketRemoveEducationInput!): Basket
+}
+
+"""Enum representing the type of price for a basket item."""
+enum BasketPriceType {
+    DEFAULT
+    MULTIBUNDLE
+    SELECT
+}
+
+"""
+Type representing a recipient for a digital gift certificate in a basket.
+"""
+type BasketRecipient {
+    """Name of the recipient."""
+    name: String
+    """Address of the recipient."""
+    address: String
+}
+
+"""Input for removing a coupon from a basket."""
+input BasketRemoveCouponInput {
+    """ID of the basket to remove the coupon from."""
+    basketId: ID!
+    """ID of the coupon to remove."""
+    couponId: ID!
+}
+
+"""Input for removing education information from a basket."""
+input BasketRemoveEducationInput {
+    """ID of the basket to remove education information from."""
+    basketId: ID!
+}
+
+"""Input for removing an item from a basket."""
+input BasketRemoveItemInput {
+    """ID of the basket to remove the item from."""
+    basketId: ID!
+    """ID of the item to remove."""
+    itemId: ID!
+}
+
+"""Input for removing a service from a basket."""
+input BasketRemoveServiceInput {
+    """ID of the basket to remove the service from."""
+    basketId: ID!
+    """ID of the service to remove."""
+    serviceId: ID!
+}
+
+"""Input for removing a subscription from a basket."""
+input BasketRemoveSubscriptionInput {
+    """ID of the basket to remove the subscription from."""
+    basketId: ID!
+    """ID of the subscription to remove."""
+    subscriptionId: ID!
+}
+
+"""Type representing a service in a basket."""
+type BasketService {
+    """Unique identifier for the service."""
+    id: ID!
+    """The product associated to the service"""
+    product: Product!
+    """Retailer offer ID associated with the service."""
+    retailerOfferId: ID!
+    """Offer UID associated with the service."""
+    offerUid: ID!
+    """Price of the service."""
+    price: BasketAmount!
+    """List of service targets associated with the service."""
+    targets: [BasketServiceTarget!]!
+}
+
+"""Type representing a service target in a basket."""
+type BasketServiceTarget {
+    """Reference value for the service target."""
+    reference: String!
+}
+
+"""Type representing a reference to a service target in a basket."""
+type BasketServiceTargetReference {
+    """Reference value for the service target."""
+    reference: String
+}
+
+"""Type representing a subscription in a basket."""
+type BasketSubscription {
+    """Unique identifier for the subscription."""
+    id: ID!
+    """Product ID associated with the subscription."""
+    subscriptionProductId: ID!
+    """Price of the subscription."""
+    price: BasketAmount!
+    """Details about the subscription."""
+    subscriptionDetail: BasketSubscriptionDetail!
+}
+
+"""Enum representing details about a subscription in a basket."""
+enum BasketSubscriptionDetail {
+    SUBSCRIPTION_PURCHASE_WITHOUT_TRIAL
+    SUBSCRIPTION_PURCHASE_WITH_TRIAL
+}
+
+"""
+Type representing a discount associated with a subscription in a basket.
+"""
+type BasketSubscriptionDiscount {
+    """Promotion ID associated with the discount."""
+    promotionId: ID!
+    """Coupon ID associated with the discount (if applicable)."""
+    couponId: ID
+    """List of subscription discount targets."""
+    targets: [BasketSubscriptionDiscountTarget!]!
+}
+
+"""Type representing a target for a subscription discount in a basket."""
+type BasketSubscriptionDiscountTarget {
+    """Reference value for the subscription discount target."""
+    reference: String
+}
+
+"""Type representing the usage of a subscription in a basket."""
+type BasketSubscriptionUsage {
+    """Amount of the subscription usage."""
+    usage: BasketAmount!
+    """Type of subscription usage (e.g., DEAL, LAST_MILE)."""
+    type: BasketSubscriptionUsageType!
+    """List of subscription usage targets."""
+    targets: [BasketSubscriptionUsageTargetType!]!
+}
+
+"""Type representing a target for subscription usage in a basket."""
+type BasketSubscriptionUsageTargetType {
+    """Reference value for the subscription usage target."""
+    reference: String
+}
+
+"""Enum representing the type of subscription usage in a basket."""
+enum BasketSubscriptionUsageType {
+    DEAL
+    LAST_MILE
+}
+
+"""Type representing the totals summary for a basket."""
+type BasketTotals {
+    """Amount to pay for the basket."""
+    toPay: BasketAmount!
+    """Amount of item totals in the basket."""
+    items: BasketAmount
+    """Amount of subscription totals in the basket."""
+    subscriptions: BasketAmount
+    """Amount of service totals in the basket."""
+    services: BasketAmount
+    """Amount of delivery totals in the basket."""
+    delivery: BasketAmount
+    """Amount of item discount totals in the basket."""
+    itemDiscounts: BasketAmount
+    """Amount of subscription usage totals in the basket."""
+    subscriptionUsages: BasketAmount
+    """Number of select points in the basket."""
+    selectPoints: Int
+}
+
+"""Input for updating education information in a basket."""
+input BasketUpdateEducationInput {
+    """ID of the basket to update education information for."""
+    basketId: ID!
+    """University information for the basket."""
+    university: String!
+    """Course information for the basket."""
+    course: String!
+}
+
+"""Input for updating the quantity of an item in a basket."""
+input BasketUpdateItemQuantityInput {
+    """ID of the basket to update the item quantity in."""
+    basketId: ID!
+    """ID of the item to update the quantity for."""
+    itemId: ID!
+    """New quantity for the item."""
+    quantity: Int!
+}
+
+"""Input for updating the shop context of a basket."""
+input BasketUpdateShopContextInput {
+    """ID of the basket to update."""
+    basketId: ID!
+    """New shop context for the basket."""
+    shopContext: String!
+}
+
+"""
+The best delivery option is the advertised delivery option, preselected by bol and balancing the needs of each stakeholder The implementation requires two mandatory headers to be present: - Bol-Shop-Country: (ISO code of) the country the offer applies to, may only be 'NL' or 'BE' - Accept-Language: the language of the customer, to localize the delivery description, may only be 'nl', 'nl-NL', 'fr' or 'fr-BE'
+"""
+type BestDeliveryOption {
+    """The release date time on which embargoes can be lifted"""
+    productReleaseDateTime: DateTime
+    """
+    This delivery option is only valid if the customer orders before this datetime
+    """
+    ultimateCustomerOrderDateTime: DateTime!
+    """
+    The latest date at which the item arrives at the customer if they order it before the ultimate customer order datetime
+    """
+    maxDateAtCustomer: Date!
+    """
+    The earliest date at which the item arrives at the customer if they order it before the ultimate customer order datetime
+    """
+    minDateAtCustomer: Date!
+    """
+    The localized delivery description, based on the Accept-Language header; either in Dutch or French
+    """
+    deliveryDescription: String!
+    """The available stock quantity, not yet supported"""
+    availableStockQuantity: Int
+}
+
+""" Representation of java.math.BigDecimal instances. These will be String on the wire
+"""
+scalar BigDecimal
+
+"""Returns a brand item object"""
+type Brand {
+    """Used for generating Brand M2 measurements"""
+    hash: String
+    """The unique identifier of the brand."""
+    id: ID!
+    """The name of the brand."""
+    name: String!
+    """The url to the brand icon."""
+    iconUrl: String!
+}
+
+"""
+A collection of brands, structured as a "connection", defined by https://relay.dev/graphql/connections.htm .
+"""
+type BrandConnection {
+    """A collection of edges that match the connection specification"""
+    edges: [BrandEdge]
+    """Metadata about the connection"""
+    pageInfo: PageInfo
+}
+
+"""Deals per brand"""
+type BrandDeals {
+    """Id of the brand (partyId)"""
+    id: ID!
+    """Name of the brand"""
+    name: String
+    """Products that are deemed interesting for the customer"""
+    products: [Product]
+    """The brand's icon url"""
+    iconUrl: String
+}
+
+"""
+The "edge" for a collection of brands. See https://relay.dev/graphql/connections.htm.
+"""
+type BrandEdge {
+    """
+    The cursor for the edge, in this case based in the index of the element
+    """
+    cursor: String
+    """The actual data tied to the cursor, in this case the product"""
+    node: Brand
+}
+
+"""Contains data needed to render a campaign page."""
+type CampaignPageResponse {
+    """Id uniquely identifying the campaign."""
+    campaignId: Int!
+    """Hero banner for this campaign."""
+    heroBanner: HeroBanner!
+    """
+    Banner which is used when there are flash deals on the campaign page. If this hero is present it should be used instead of `heroBanner`.
+    """
+    flashDealsHero: FlashDealsHero
+    """Moat Flash deals for this campaign page."""
+    moatFlashDeals: [MoatFlashDeal!]!
+    """A section of party cards."""
+    moatPartyCards: MoatPartyCards
+    """Promotion cards for this campaign page."""
+    promotionCards: [PromotionCard!]!
+    """A product carousel."""
+    moatProductCarousel: MoatProductCarousel
+    """Moat Day deals for the campaign page."""
+    moatDayDeals: [MoatDayDeal!]!
+    """Theme cards of the campaign page."""
+    moatThemeCards: MoatThemeCards
+    """HTML version of the SEO text snippet."""
+    seoSnippetHtml: String
+    """SEO metadata for this campaign page."""
+    seoMetadata: CmsSeoMetadata!
+    """Upcoming flash deals info."""
+    upcomingFlashDealsInfo: [UpcomingFlashDealInfo!]!
+}
+
+"""A CMS component which navigates to different categories."""
+type CategoryNavigation {
+    """Header."""
+    header: CmsHeader!
+    """Links to the categories."""
+    links: [Link!]!
+}
+
+"""A circle hero is a type of banner which contains a circular image."""
+type CircleHero {
+    """Display title."""
+    title: String!
+    """Optional subtitle."""
+    subtitle: String
+    """Image."""
+    image: Image!
+    """Background color in HEX."""
+    backgroundColor: String!
+    """Paragraph."""
+    paragraph: String
+    """Buttons."""
+    buttons: [MoatButton!]!
+}
+
+"""A CMS component on a page."""
+union CmsComponent = MoatJumpstationCards | CategoryNavigation | MoatTextSnippet | MoatThemeCards | Editorial | MoatPartyCards | MoatProductCarousel | MoatInformationCards | MoatVideo
+
+"""A type of header used in CMS types."""
+type CmsHeader {
+    """Title."""
+    title: String!
+    """Optional subtitle."""
+    subtitle: String
+}
+
+type cmsQuery {
+    assets(uid: String!, locale: String = "nl-nl", fallback_locale: Boolean = false): CS_SysAsset
+    all_assets(where: CS_SysAssetWhere, locale: String = "nl-nl", order_by: [CS_SysAssetOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllSysAsset
+    information_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_InformationPage
+    all_information_page(where: CS_InformationPageWhere, locale: String! = "nl-nl", order_by: [CS_InformationPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllInformationPage
+    storefront_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_StorefrontPage
+    all_storefront_page(where: CS_StorefrontPageWhere, locale: String! = "nl-nl", order_by: [CS_StorefrontPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllStorefrontPage
+    customer_alert_message(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_CustomerAlertMessage
+    all_customer_alert_message(where: CS_CustomerAlertMessageWhere, locale: String! = "nl-nl", order_by: [CS_CustomerAlertMessageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllCustomerAlertMessage
+    brand_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_BrandPage
+    all_brand_page(where: CS_BrandPageWhere, locale: String! = "nl-nl", order_by: [CS_BrandPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllBrandPage
+    menu_tabs(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_MenuTabs
+    all_menu_tabs(where: CS_MenuTabsWhere, locale: String! = "nl-nl", order_by: [CS_MenuTabsOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllMenuTabs
+    size_guide(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_SizeGuide
+    all_size_guide(where: CS_SizeGuideWhere, locale: String! = "nl-nl", order_by: [CS_SizeGuideOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllSizeGuide
+    brand_campaign_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_BrandCampaignPage
+    all_brand_campaign_page(where: CS_BrandCampaignPageWhere, locale: String! = "nl-nl", order_by: [CS_BrandCampaignPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllBrandCampaignPage
+    home_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_HomePage
+    all_home_page(where: CS_HomePageWhere, locale: String! = "nl-nl", order_by: [CS_HomePageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllHomePage
+    mhp_top_banner(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_MhpTopBanner
+    all_mhp_top_banner(where: CS_MhpTopBannerWhere, locale: String! = "nl-nl", order_by: [CS_MhpTopBannerOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllMhpTopBanner
+    marketing_menu(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_MarketingMenu
+    all_marketing_menu(where: CS_MarketingMenuWhere, locale: String! = "nl-nl", order_by: [CS_MarketingMenuOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllMarketingMenu
+    campaign_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_CampaignPage
+    all_campaign_page(where: CS_CampaignPageWhere, locale: String! = "nl-nl", order_by: [CS_CampaignPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllCampaignPage
+    basicbanner(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_Basicbanner
+    all_basicbanner(where: CS_BasicbannerWhere, locale: String! = "nl-nl", order_by: [CS_BasicbannerOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllBasicbanner
+    circle_hero(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_CircleHero
+    all_circle_hero(where: CS_CircleHeroWhere, locale: String! = "nl-nl", order_by: [CS_CircleHeroOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllCircleHero
+    app_banner(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_AppBanner
+    all_app_banner(where: CS_AppBannerWhere, locale: String! = "nl-nl", order_by: [CS_AppBannerOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllAppBanner
+    legal_article(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_LegalArticle
+    all_legal_article(where: CS_LegalArticleWhere, locale: String! = "nl-nl", order_by: [CS_LegalArticleOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllLegalArticle
+    app_banner_carousel(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_AppBannerCarousel
+    all_app_banner_carousel(where: CS_AppBannerCarouselWhere, locale: String! = "nl-nl", order_by: [CS_AppBannerCarouselOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllAppBannerCarousel
+    legal_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_LegalPage
+    all_legal_page(where: CS_LegalPageWhere, locale: String! = "nl-nl", order_by: [CS_LegalPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllLegalPage
+    legal_overview_page(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_LegalOverviewPage
+    all_legal_overview_page(where: CS_LegalOverviewPageWhere, locale: String! = "nl-nl", order_by: [CS_LegalOverviewPageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllLegalOverviewPage
+    emergency_message_container(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_EmergencyMessageContainer
+    all_emergency_message_container(where: CS_EmergencyMessageContainerWhere, locale: String! = "nl-nl", order_by: [CS_EmergencyMessageContainerOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllEmergencyMessageContainer
+    emergency_message(uid: String!, locale: String! = "nl-nl", fallback_locale: Boolean = false): CS_EmergencyMessage
+    all_emergency_message(where: CS_EmergencyMessageWhere, locale: String! = "nl-nl", order_by: [CS_EmergencyMessageOrderBy] = [updated_at_DESC], skip: Int = 0, limit: Int = 25, fallback_locale: Boolean = false): CS_AllEmergencyMessage
+}
+
+"""Metadata used for SEO metadata coming from CMS."""
+type CmsSeoMetadata {
+    """SEO title."""
+    title: String!
+    """SEO description."""
+    description: String!
+    """
+    Used for robots 'noindex' meta tag, which instructs search engines not to index a web page.
+    """
+    noIndex: Boolean!
+    """
+    Used for robots 'nofollow' meta tag, which instructs search engines not to follow or crawl the links on a web page.
+    """
+    noFollow: Boolean!
+    """
+    The 'canonical URL' tag instructs search engines the preferred URL for a webpage.
+    """
+    canonicalUrl: String
+    """
+    The 'lang' tag specifies the language of the content on a webpage, aiding in language identification and localization.
+    """
+    lang: String
+}
+
+"""Color attributes."""
+type Color {
+    """Light value of the color."""
+    light: String!
+    """Dark value of the color."""
+    dark: String!
+}
+
+"""
+Consent associated with device and/or customer - Anonymous user has only data usage consent associated with device - Logged user has data usage consent where transactional choices associated with the user and behavioral choices with device; also it is possible to have data sharing consent
+"""
+type Consent {
+    """Data usage consent"""
+    dataUsage: DataUsageConsent!
+    """
+    Data sharing consent, can be null if data usage consent is missing, detected location is not Netherlands or user not logged in
+    """
+    dataSharing: DataSharingConsent
+}
+
+"""Consent mutations"""
+type ConsentMutations {
+    """Set data usage consent"""
+    updateDataUsageConsent(dataUsageInput: DataUsageInput): UpdateDataUsageConsentResult
+    """Set data sharing consent"""
+    updateDataSharingConsent(dataSharingInput: DataSharingInput): UpdateDataSharingConsentResult
+}
+
+"""Enumeration that specifies the possible country regions."""
+enum Country {
+    """The Netherlands"""
+    NL
+    """Belgium"""
+    BE
+}
+
+type CS__Service {
+    """
+    The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied
+    """
+    sdl: String
+}
+
+type CS_AllAppBanner {
+    total: Int
+    items: [CS_AppBanner]
+}
+
+type CS_AllAppBannerCarousel {
+    total: Int
+    items: [CS_AppBannerCarousel]
+}
+
+type CS_AllBasicbanner {
+    total: Int
+    items: [CS_Basicbanner]
+}
+
+type CS_AllBrandCampaignPage {
+    total: Int
+    items: [CS_BrandCampaignPage]
+}
+
+type CS_AllBrandPage {
+    total: Int
+    items: [CS_BrandPage]
+}
+
+type CS_AllCampaignPage {
+    total: Int
+    items: [CS_CampaignPage]
+}
+
+type CS_AllCircleHero {
+    total: Int
+    items: [CS_CircleHero]
+}
+
+type CS_AllCustomerAlertMessage {
+    total: Int
+    items: [CS_CustomerAlertMessage]
+}
+
+type CS_AllEmergencyMessage {
+    total: Int
+    items: [CS_EmergencyMessage]
+}
+
+type CS_AllEmergencyMessageContainer {
+    total: Int
+    items: [CS_EmergencyMessageContainer]
+}
+
+type CS_AllHomePage {
+    total: Int
+    items: [CS_HomePage]
+}
+
+type CS_AllInformationPage {
+    total: Int
+    items: [CS_InformationPage]
+}
+
+type CS_AllLegalArticle {
+    total: Int
+    items: [CS_LegalArticle]
+}
+
+type CS_AllLegalOverviewPage {
+    total: Int
+    items: [CS_LegalOverviewPage]
+}
+
+type CS_AllLegalPage {
+    total: Int
+    items: [CS_LegalPage]
+}
+
+type CS_AllMarketingMenu {
+    total: Int
+    items: [CS_MarketingMenu]
+}
+
+type CS_AllMenuTabs {
+    total: Int
+    items: [CS_MenuTabs]
+}
+
+type CS_AllMhpTopBanner {
+    total: Int
+    items: [CS_MhpTopBanner]
+}
+
+type CS_AllSizeGuide {
+    total: Int
+    items: [CS_SizeGuide]
+}
+
+type CS_AllStorefrontPage {
+    total: Int
+    items: [CS_StorefrontPage]
+}
+
+type CS_AllSysAsset {
+    total: Int
+    items: [CS_SysAsset]
+}
+
+type CS_AppBanner {
+    title: String
+    start_date: DateTime
+    end_date: DateTime
+    text: String
+    text_color: String
+    image_url: String
+    landing_page_url: String
+    promo_code: String
+    system: CS_EntrySystemField
+}
+
+type CS_AppBannerCarousel {
+    title: String
+    bannersConnection(skip: Int = 0, limit: Int = 100): CS_AppBannerCarouselBannersConnection
+    system: CS_EntrySystemField
+}
+
+type CS_AppBannerCarouselBannersConnection {
+    totalCount: Int
+    edges: [CS_AppBannerCarouselBannersEdge]
+}
+
+type CS_AppBannerCarouselBannersEdge {
+    node: CS_AppBannerCarouselBannersNode
+}
+
+union CS_AppBannerCarouselBannersNode = CS_AppBanner
+
+input CS_AppBannerCarouselBannersWhere {
+    app_banner: CS_AppBannerWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+enum CS_AppBannerCarouselOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_AppBannerCarouselWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    banners: CS_AppBannerCarouselBannersWhere
+    banners_count: Int
+    banners_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_AppBannerCarouselWhere]
+    OR: [CS_AppBannerCarouselWhere]
+}
+
+enum CS_AppBannerOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_AppBannerWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    start_date: DateTime
+    start_date_in: [DateTime]
+    start_date_nin: [DateTime]
+    start_date_exists: Boolean
+    start_date_ne: DateTime
+    start_date_lt: DateTime
+    start_date_lte: DateTime
+    start_date_gt: DateTime
+    start_date_gte: DateTime
+    end_date: DateTime
+    end_date_in: [DateTime]
+    end_date_nin: [DateTime]
+    end_date_exists: Boolean
+    end_date_ne: DateTime
+    end_date_lt: DateTime
+    end_date_lte: DateTime
+    end_date_gt: DateTime
+    end_date_gte: DateTime
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    text_color: String
+    text_color_ne: String
+    text_color_in: [String]
+    text_color_nin: [String]
+    text_color_exists: Boolean
+    image_url: String
+    image_url_ne: String
+    image_url_in: [String]
+    image_url_nin: [String]
+    image_url_exists: Boolean
+    landing_page_url: String
+    landing_page_url_ne: String
+    landing_page_url_in: [String]
+    landing_page_url_nin: [String]
+    landing_page_url_exists: Boolean
+    promo_code: String
+    promo_code_ne: String
+    promo_code_in: [String]
+    promo_code_nin: [String]
+    promo_code_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_AppBannerWhere]
+    OR: [CS_AppBannerWhere]
+}
+
+type CS_Basicbanner {
+    title: String
+    display_title: String
+    subtitle: String
+    url: String
+    background_color: JSON
+    imageConnection: CS_SysAssetConnection
+    button_title: String
+    system: CS_EntrySystemField
+}
+
+enum CS_BasicbannerOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_BasicbannerWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    button_title: String
+    button_title_ne: String
+    button_title_in: [String]
+    button_title_nin: [String]
+    button_title_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_BasicbannerWhere]
+    OR: [CS_BasicbannerWhere]
+}
+
+type CS_BrandCampaignPage {
+    title: String
+    page_title: String
+    brandConnection: CS_BrandCampaignPageBrandConnection
+    advertising_campaign_id: String
+    brand_campaign_hero: CS_BrandCampaignPageBrandCampaignHero
+    middle_slot: [CS_BrandCampaignPageMiddleSlot]
+    seo_snippet: CS_BrandCampaignPageSeoSnippet
+    seo_metadata: CS_SeoMetadata
+    read_only_url: String
+    system: CS_EntrySystemField
+}
+
+type CS_BrandCampaignPageBrandCampaignHero {
+    imageConnection: CS_SysAssetConnection
+    background_color: JSON
+    title: String
+    title_color: JSON
+    subtitle: String
+    subtitle_color: JSON
+}
+
+input CS_BrandCampaignPageBrandCampaignHeroWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    title_color: JSON
+    title_color_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    subtitle_color: JSON
+    subtitle_color_exists: Boolean
+}
+
+type CS_BrandCampaignPageBrandConnection {
+    totalCount: Int
+    edges: [CS_BrandCampaignPageBrandEdge]
+}
+
+type CS_BrandCampaignPageBrandEdge {
+    node: CS_BrandCampaignPageBrandNode
+}
+
+union CS_BrandCampaignPageBrandNode = CS_BrandPage
+
+input CS_BrandCampaignPageBrandWhere {
+    brand_page: CS_BrandPageWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+union CS_BrandCampaignPageMiddleSlot = CS_BrandCampaignPageMiddleSlotThemeCards | CS_BrandCampaignPageMiddleSlotVideo | CS_BrandCampaignPageMiddleSlotEditorial | CS_BrandCampaignPageMiddleSlotCatalog | CS_BrandCampaignPageMiddleSlotProductCarousel | CS_BrandCampaignPageMiddleSlotPartyCards
+
+type CS_BrandCampaignPageMiddleSlotCatalog {
+    catalog: CS_Catalog
+}
+
+input CS_BrandCampaignPageMiddleSlotCatalogWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    bold_title: Boolean
+    bold_title_exists: Boolean
+    bold_title_ne: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    size: Float
+    size_in: [Float]
+    size_nin: [Float]
+    size_exists: Boolean
+    size_ne: Float
+    size_lt: Float
+    size_lte: Float
+    size_gt: Float
+    size_gte: Float
+    background_color: JSON
+    background_color_exists: Boolean
+    position: String
+    position_ne: String
+    position_in: [String]
+    position_nin: [String]
+    position_exists: Boolean
+    products: CS_CatalogProductsWhere
+    products_exists: Boolean
+}
+
+type CS_BrandCampaignPageMiddleSlotEditorial {
+    editorial: CS_Editorial
+}
+
+input CS_BrandCampaignPageMiddleSlotEditorialWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_position: String
+    image_position_ne: String
+    image_position_in: [String]
+    image_position_nin: [String]
+    image_position_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    primary_link: CS_LinkWhere
+    primary_link_exists: Boolean
+    secondary_link: CS_LinkWhere
+    secondary_link_exists: Boolean
+}
+
+type CS_BrandCampaignPageMiddleSlotPartyCards {
+    party_cards: CS_PartyCards
+}
+
+input CS_BrandCampaignPageMiddleSlotPartyCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    hide_titles: Boolean
+    hide_titles_exists: Boolean
+    hide_titles_ne: Boolean
+    sponsored: Boolean
+    sponsored_exists: Boolean
+    sponsored_ne: Boolean
+    cards: CS_PartyCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_BrandCampaignPageMiddleSlotProductCarousel {
+    product_carousel: CS_ProductCarousel
+}
+
+input CS_BrandCampaignPageMiddleSlotProductCarouselWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    products: CS_ProductCarouselProductsWhere
+    products_exists: Boolean
+}
+
+type CS_BrandCampaignPageMiddleSlotThemeCards {
+    theme_cards: CS_ThemeCards
+}
+
+input CS_BrandCampaignPageMiddleSlotThemeCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    cards: CS_ThemeCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_BrandCampaignPageMiddleSlotVideo {
+    video: CS_Video
+}
+
+input CS_BrandCampaignPageMiddleSlotVideoWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    video: CS_SysAssetWhere
+    video_exists: Boolean
+    autoplay: Boolean
+    autoplay_exists: Boolean
+    autoplay_ne: Boolean
+    thumbnail: CS_SysAssetWhere
+    thumbnail_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+}
+
+input CS_BrandCampaignPageMiddleSlotWhere {
+    theme_cards: CS_BrandCampaignPageMiddleSlotThemeCardsWhere
+    theme_cards_exists: Boolean
+    video: CS_BrandCampaignPageMiddleSlotVideoWhere
+    video_exists: Boolean
+    editorial: CS_BrandCampaignPageMiddleSlotEditorialWhere
+    editorial_exists: Boolean
+    catalog: CS_BrandCampaignPageMiddleSlotCatalogWhere
+    catalog_exists: Boolean
+    product_carousel: CS_BrandCampaignPageMiddleSlotProductCarouselWhere
+    product_carousel_exists: Boolean
+    party_cards: CS_BrandCampaignPageMiddleSlotPartyCardsWhere
+    party_cards_exists: Boolean
+}
+
+enum CS_BrandCampaignPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_BrandCampaignPageSeoSnippet {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_BrandCampaignPageSeoSnippetEmbeddedItemsConnection
+}
+
+type CS_BrandCampaignPageSeoSnippetEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_BrandCampaignPageSeoSnippetEmbeddedItemsEdge]
+}
+
+type CS_BrandCampaignPageSeoSnippetEmbeddedItemsEdge {
+    node: CS_BrandCampaignPageSeoSnippetEmbeddedItemsNode
+}
+
+union CS_BrandCampaignPageSeoSnippetEmbeddedItemsNode = CS_SysAsset
+
+input CS_BrandCampaignPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    page_title: String
+    page_title_ne: String
+    page_title_in: [String]
+    page_title_nin: [String]
+    page_title_exists: Boolean
+    brand: CS_BrandCampaignPageBrandWhere
+    brand_exists: Boolean
+    advertising_campaign_id: String
+    advertising_campaign_id_ne: String
+    advertising_campaign_id_in: [String]
+    advertising_campaign_id_nin: [String]
+    advertising_campaign_id_exists: Boolean
+    brand_campaign_hero: CS_BrandCampaignPageBrandCampaignHeroWhere
+    brand_campaign_hero_exists: Boolean
+    middle_slot: CS_BrandCampaignPageMiddleSlotWhere
+    middle_slot_exists: Boolean
+    seo_snippet: JSON
+    seo_snippet_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    read_only_url: String
+    read_only_url_ne: String
+    read_only_url_in: [String]
+    read_only_url_nin: [String]
+    read_only_url_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_BrandCampaignPageWhere]
+    OR: [CS_BrandCampaignPageWhere]
+}
+
+type CS_BrandPage {
+    title: String
+    party_id: String
+    advertiser_id: String
+    brand_logo: CS_BrandPageBrandLogo
+    brand_hero: CS_BrandPageBrandHero
+    middle_slot: [CS_BrandPageMiddleSlot]
+    seo_snippet: CS_BrandPageSeoSnippet
+    seo_metadata: CS_SeoMetadata
+    system: CS_EntrySystemField
+}
+
+type CS_BrandPageBrandHero {
+    imageConnection: CS_SysAssetConnection
+    contained: Boolean
+    background_color: JSON
+    brand_title: String
+    subtitle: String
+    text_color: JSON
+}
+
+input CS_BrandPageBrandHeroWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    brand_title: String
+    brand_title_ne: String
+    brand_title_in: [String]
+    brand_title_nin: [String]
+    brand_title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text_color: JSON
+    text_color_exists: Boolean
+}
+
+type CS_BrandPageBrandLogo {
+    imageConnection: CS_SysAssetConnection
+    type: String
+}
+
+input CS_BrandPageBrandLogoWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    type: String
+    type_ne: String
+    type_in: [String]
+    type_nin: [String]
+    type_exists: Boolean
+}
+
+union CS_BrandPageMiddleSlot = CS_BrandPageMiddleSlotThemeCards | CS_BrandPageMiddleSlotVideo | CS_BrandPageMiddleSlotEditorial | CS_BrandPageMiddleSlotCatalog | CS_BrandPageMiddleSlotProductCarousel | CS_BrandPageMiddleSlotPartyCards
+
+type CS_BrandPageMiddleSlotCatalog {
+    catalog: CS_Catalog
+}
+
+input CS_BrandPageMiddleSlotCatalogWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    bold_title: Boolean
+    bold_title_exists: Boolean
+    bold_title_ne: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    size: Float
+    size_in: [Float]
+    size_nin: [Float]
+    size_exists: Boolean
+    size_ne: Float
+    size_lt: Float
+    size_lte: Float
+    size_gt: Float
+    size_gte: Float
+    background_color: JSON
+    background_color_exists: Boolean
+    position: String
+    position_ne: String
+    position_in: [String]
+    position_nin: [String]
+    position_exists: Boolean
+    products: CS_CatalogProductsWhere
+    products_exists: Boolean
+}
+
+type CS_BrandPageMiddleSlotEditorial {
+    editorial: CS_Editorial
+}
+
+input CS_BrandPageMiddleSlotEditorialWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_position: String
+    image_position_ne: String
+    image_position_in: [String]
+    image_position_nin: [String]
+    image_position_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    primary_link: CS_LinkWhere
+    primary_link_exists: Boolean
+    secondary_link: CS_LinkWhere
+    secondary_link_exists: Boolean
+}
+
+type CS_BrandPageMiddleSlotPartyCards {
+    party_cards: CS_PartyCards
+}
+
+input CS_BrandPageMiddleSlotPartyCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    hide_titles: Boolean
+    hide_titles_exists: Boolean
+    hide_titles_ne: Boolean
+    sponsored: Boolean
+    sponsored_exists: Boolean
+    sponsored_ne: Boolean
+    cards: CS_PartyCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_BrandPageMiddleSlotProductCarousel {
+    product_carousel: CS_ProductCarousel
+}
+
+input CS_BrandPageMiddleSlotProductCarouselWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    products: CS_ProductCarouselProductsWhere
+    products_exists: Boolean
+}
+
+type CS_BrandPageMiddleSlotThemeCards {
+    theme_cards: CS_ThemeCards
+}
+
+input CS_BrandPageMiddleSlotThemeCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    cards: CS_ThemeCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_BrandPageMiddleSlotVideo {
+    video: CS_Video
+}
+
+input CS_BrandPageMiddleSlotVideoWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    video: CS_SysAssetWhere
+    video_exists: Boolean
+    autoplay: Boolean
+    autoplay_exists: Boolean
+    autoplay_ne: Boolean
+    thumbnail: CS_SysAssetWhere
+    thumbnail_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+}
+
+input CS_BrandPageMiddleSlotWhere {
+    theme_cards: CS_BrandPageMiddleSlotThemeCardsWhere
+    theme_cards_exists: Boolean
+    video: CS_BrandPageMiddleSlotVideoWhere
+    video_exists: Boolean
+    editorial: CS_BrandPageMiddleSlotEditorialWhere
+    editorial_exists: Boolean
+    catalog: CS_BrandPageMiddleSlotCatalogWhere
+    catalog_exists: Boolean
+    product_carousel: CS_BrandPageMiddleSlotProductCarouselWhere
+    product_carousel_exists: Boolean
+    party_cards: CS_BrandPageMiddleSlotPartyCardsWhere
+    party_cards_exists: Boolean
+}
+
+enum CS_BrandPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_BrandPageSeoSnippet {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_BrandPageSeoSnippetEmbeddedItemsConnection
+}
+
+type CS_BrandPageSeoSnippetEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_BrandPageSeoSnippetEmbeddedItemsEdge]
+}
+
+type CS_BrandPageSeoSnippetEmbeddedItemsEdge {
+    node: CS_BrandPageSeoSnippetEmbeddedItemsNode
+}
+
+union CS_BrandPageSeoSnippetEmbeddedItemsNode = CS_SysAsset
+
+input CS_BrandPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    party_id: String
+    party_id_ne: String
+    party_id_in: [String]
+    party_id_nin: [String]
+    party_id_exists: Boolean
+    advertiser_id: String
+    advertiser_id_ne: String
+    advertiser_id_in: [String]
+    advertiser_id_nin: [String]
+    advertiser_id_exists: Boolean
+    brand_logo: CS_BrandPageBrandLogoWhere
+    brand_logo_exists: Boolean
+    brand_hero: CS_BrandPageBrandHeroWhere
+    brand_hero_exists: Boolean
+    middle_slot: CS_BrandPageMiddleSlotWhere
+    middle_slot_exists: Boolean
+    seo_snippet: JSON
+    seo_snippet_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_BrandPageWhere]
+    OR: [CS_BrandPageWhere]
+}
+
+type CS_CampaignPage {
+    title: String
+    campaign_id: Float
+    show_flash_deals_hero: Boolean
+    flash_deals_hero: CS_CampaignPageFlashDealsHero
+    campaign_hero: CS_CampaignPageCampaignHero
+    party_cards: CS_PartyCards
+    product_carousel: CS_ProductCarousel
+    theme_cards: CS_ThemeCards
+    seo_snippet: CS_CampaignPageSeoSnippet
+    seo_metadata: CS_SeoMetadata
+    system: CS_EntrySystemField
+}
+
+type CS_CampaignPageCampaignHero {
+    imageConnection: CS_SysAssetConnection
+    background_color: String
+    title: String
+    subtitle: String
+}
+
+input CS_CampaignPageCampaignHeroWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+}
+
+type CS_CampaignPageFlashDealsHero {
+    desktop_imageConnection: CS_SysAssetConnection
+    mobile_imageConnection: CS_SysAssetConnection
+    background_color: String
+    title: String
+    flash_deals_background_color: String
+}
+
+input CS_CampaignPageFlashDealsHeroWhere {
+    desktop_image: CS_SysAssetWhere
+    desktop_image_exists: Boolean
+    mobile_image: CS_SysAssetWhere
+    mobile_image_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    flash_deals_background_color: String
+    flash_deals_background_color_ne: String
+    flash_deals_background_color_in: [String]
+    flash_deals_background_color_nin: [String]
+    flash_deals_background_color_exists: Boolean
+}
+
+enum CS_CampaignPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_CampaignPageSeoSnippet {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_CampaignPageSeoSnippetEmbeddedItemsConnection
+}
+
+type CS_CampaignPageSeoSnippetEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_CampaignPageSeoSnippetEmbeddedItemsEdge]
+}
+
+type CS_CampaignPageSeoSnippetEmbeddedItemsEdge {
+    node: CS_CampaignPageSeoSnippetEmbeddedItemsNode
+}
+
+union CS_CampaignPageSeoSnippetEmbeddedItemsNode = CS_SysAsset
+
+input CS_CampaignPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    campaign_id: Float
+    campaign_id_in: [Float]
+    campaign_id_nin: [Float]
+    campaign_id_exists: Boolean
+    campaign_id_ne: Float
+    campaign_id_lt: Float
+    campaign_id_lte: Float
+    campaign_id_gt: Float
+    campaign_id_gte: Float
+    show_flash_deals_hero: Boolean
+    show_flash_deals_hero_exists: Boolean
+    show_flash_deals_hero_ne: Boolean
+    flash_deals_hero: CS_CampaignPageFlashDealsHeroWhere
+    flash_deals_hero_exists: Boolean
+    campaign_hero: CS_CampaignPageCampaignHeroWhere
+    campaign_hero_exists: Boolean
+    party_cards: CS_PartyCardsWhere
+    party_cards_exists: Boolean
+    product_carousel: CS_ProductCarouselWhere
+    product_carousel_exists: Boolean
+    theme_cards: CS_ThemeCardsWhere
+    theme_cards_exists: Boolean
+    seo_snippet: JSON
+    seo_snippet_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_CampaignPageWhere]
+    OR: [CS_CampaignPageWhere]
+}
+
+type CS_Catalog {
+    title: String
+    subtitle: String
+    bold_title: Boolean
+    url: CS_Link
+    imageConnection: CS_SysAssetConnection
+    size: Float
+    background_color: JSON
+    position: String
+    products: [CS_CatalogProducts]
+}
+
+type CS_CatalogProducts {
+    global_id: String
+    product: Product
+}
+
+input CS_CatalogProductsWhere {
+    global_id: String
+    global_id_ne: String
+    global_id_in: [String]
+    global_id_nin: [String]
+    global_id_exists: Boolean
+}
+
+type CS_CategoryNavigation {
+    title: String
+    subtitle: String
+    links: [CS_Link]
+}
+
+type CS_CircleHero {
+    title: String
+    display_title: String
+    subtitle: String
+    imageConnection: CS_SysAssetConnection
+    background_color: String
+    paragraph: String
+    buttons: [CS_CircleHeroButtons]
+    system: CS_EntrySystemField
+}
+
+type CS_CircleHeroButtons {
+    title: String
+    url: String
+    appearance: String
+}
+
+input CS_CircleHeroButtonsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    appearance: String
+    appearance_ne: String
+    appearance_in: [String]
+    appearance_nin: [String]
+    appearance_exists: Boolean
+}
+
+enum CS_CircleHeroOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_CircleHeroWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    paragraph: String
+    paragraph_ne: String
+    paragraph_in: [String]
+    paragraph_nin: [String]
+    paragraph_exists: Boolean
+    buttons: CS_CircleHeroButtonsWhere
+    buttons_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_CircleHeroWhere]
+    OR: [CS_CircleHeroWhere]
+}
+
+type CS_CustomerAlertMessage {
+    title: String
+    display_title: String
+    message: String
+    urgency: String
+    display: Boolean
+    page: [String]
+    system: CS_EntrySystemField
+}
+
+enum CS_CustomerAlertMessageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_CustomerAlertMessageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    message: String
+    message_ne: String
+    message_in: [String]
+    message_nin: [String]
+    message_exists: Boolean
+    urgency: String
+    urgency_ne: String
+    urgency_in: [String]
+    urgency_nin: [String]
+    urgency_exists: Boolean
+    display: Boolean
+    display_exists: Boolean
+    display_ne: Boolean
+    page: String
+    page_ne: String
+    page_in: [String]
+    page_nin: [String]
+    page_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_CustomerAlertMessageWhere]
+    OR: [CS_CustomerAlertMessageWhere]
+}
+
+type CS_Editorial {
+    title: String
+    subtitle: String
+    text: String
+    imageConnection: CS_SysAssetConnection
+    image_position: String
+    background_color: String
+    background_color_v2: JSON
+    primary_link: CS_Link
+    secondary_link: CS_Link
+}
+
+type CS_EmergencyMessage {
+    title: String
+    display_title: String
+    message: String
+    system: CS_EntrySystemField
+}
+
+type CS_EmergencyMessageContainer {
+    title: String
+    emergency_messageConnection: CS_EmergencyMessageContainerEmergencyMessageConnection
+    urgency: String
+    display: Boolean
+    system: CS_EntrySystemField
+}
+
+type CS_EmergencyMessageContainerEmergencyMessageConnection {
+    totalCount: Int
+    edges: [CS_EmergencyMessageContainerEmergencyMessageEdge]
+}
+
+type CS_EmergencyMessageContainerEmergencyMessageEdge {
+    node: CS_EmergencyMessageContainerEmergencyMessageNode
+}
+
+union CS_EmergencyMessageContainerEmergencyMessageNode = CS_EmergencyMessage
+
+input CS_EmergencyMessageContainerEmergencyMessageWhere {
+    emergency_message: CS_EmergencyMessageWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+enum CS_EmergencyMessageContainerOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_EmergencyMessageContainerWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    emergency_message: CS_EmergencyMessageContainerEmergencyMessageWhere
+    emergency_message_exists: Boolean
+    urgency: String
+    urgency_ne: String
+    urgency_in: [String]
+    urgency_nin: [String]
+    urgency_exists: Boolean
+    display: Boolean
+    display_exists: Boolean
+    display_ne: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_EmergencyMessageContainerWhere]
+    OR: [CS_EmergencyMessageContainerWhere]
+}
+
+enum CS_EmergencyMessageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_EmergencyMessageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    message: String
+    message_ne: String
+    message_in: [String]
+    message_nin: [String]
+    message_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_EmergencyMessageWhere]
+    OR: [CS_EmergencyMessageWhere]
+}
+
+type CS_EntrySystemField {
+    branch: String
+    created_at: DateTime
+    publish_details: CS_SystemPublishDetails
+    updated_at: DateTime
+    created_by: String
+    updated_by: String
+    uid: String
+    tags: [String]
+    version: Int
+    content_type_uid: String
+    locale: String
+    extensionConnection(skip: Int = 0, limit: Int = 25): CS_SysExtensionConnection
+}
+
+enum CS_EvalReferenceEnum {
+    ANY
+    ALL
+}
+
+type CS_HomePage {
+    title: String
+    brand_activation_pages_slot: CS_HomePageBrandActivationPagesSlot
+    app_banners: CS_HomePageAppBanners
+    all_deals_card: CS_MediaCard
+    shop_the_look_card: CS_MediaCard
+    gift_entries_slot: CS_HomePageGiftEntriesSlot
+    system: CS_EntrySystemField
+}
+
+type CS_HomePageAppBanners {
+    banner_group_1Connection: CS_HomePageAppBannersBannerGroup1Connection
+    banner_group_2Connection: CS_HomePageAppBannersBannerGroup2Connection
+}
+
+type CS_HomePageAppBannersBannerGroup1Connection {
+    totalCount: Int
+    edges: [CS_HomePageAppBannersBannerGroup1Edge]
+}
+
+type CS_HomePageAppBannersBannerGroup1Edge {
+    node: CS_HomePageAppBannersBannerGroup1Node
+}
+
+union CS_HomePageAppBannersBannerGroup1Node = CS_AppBannerCarousel
+
+input CS_HomePageAppBannersBannerGroup1Where {
+    app_banner_carousel: CS_AppBannerCarouselWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+type CS_HomePageAppBannersBannerGroup2Connection {
+    totalCount: Int
+    edges: [CS_HomePageAppBannersBannerGroup2Edge]
+}
+
+type CS_HomePageAppBannersBannerGroup2Edge {
+    node: CS_HomePageAppBannersBannerGroup2Node
+}
+
+union CS_HomePageAppBannersBannerGroup2Node = CS_AppBannerCarousel
+
+input CS_HomePageAppBannersBannerGroup2Where {
+    app_banner_carousel: CS_AppBannerCarouselWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+input CS_HomePageAppBannersWhere {
+    banner_group_1: CS_HomePageAppBannersBannerGroup1Where
+    banner_group_1_exists: Boolean
+    banner_group_2: CS_HomePageAppBannersBannerGroup2Where
+    banner_group_2_exists: Boolean
+}
+
+type CS_HomePageBrandActivationPagesSlot {
+    title: String
+    subtitle: String
+    entriesConnection(skip: Int = 0, limit: Int = 100): CS_HomePageBrandActivationPagesSlotEntriesConnection
+}
+
+type CS_HomePageBrandActivationPagesSlotEntriesConnection {
+    totalCount: Int
+    edges: [CS_HomePageBrandActivationPagesSlotEntriesEdge]
+}
+
+type CS_HomePageBrandActivationPagesSlotEntriesEdge {
+    node: CS_HomePageBrandActivationPagesSlotEntriesNode
+}
+
+union CS_HomePageBrandActivationPagesSlotEntriesNode = CS_BrandCampaignPage
+
+input CS_HomePageBrandActivationPagesSlotEntriesWhere {
+    brand_campaign_page: CS_BrandCampaignPageWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+input CS_HomePageBrandActivationPagesSlotWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    entries: CS_HomePageBrandActivationPagesSlotEntriesWhere
+    entries_count: Int
+    entries_exists: Boolean
+}
+
+type CS_HomePageGiftEntriesSlot {
+    title: String
+    subtitle: String
+    entries: [CS_MediaCard]
+}
+
+input CS_HomePageGiftEntriesSlotWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    entries: CS_MediaCardWhere
+    entries_exists: Boolean
+}
+
+enum CS_HomePageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_HomePageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    brand_activation_pages_slot: CS_HomePageBrandActivationPagesSlotWhere
+    brand_activation_pages_slot_exists: Boolean
+    app_banners: CS_HomePageAppBannersWhere
+    app_banners_exists: Boolean
+    all_deals_card: CS_MediaCardWhere
+    all_deals_card_exists: Boolean
+    shop_the_look_card: CS_MediaCardWhere
+    shop_the_look_card_exists: Boolean
+    gift_entries_slot: CS_HomePageGiftEntriesSlotWhere
+    gift_entries_slot_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_HomePageWhere]
+    OR: [CS_HomePageWhere]
+}
+
+type CS_InformationCards {
+    title: String
+    subtitle: String
+    display_mode: String
+    image_ratio: String
+    background_color: String
+    cards: [CS_InformationCardsCards]
+}
+
+type CS_InformationCardsCards {
+    title: String
+    paragraph: String
+    link: CS_Link
+    imageConnection: CS_SysAssetConnection
+}
+
+input CS_InformationCardsCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    paragraph: String
+    paragraph_ne: String
+    paragraph_in: [String]
+    paragraph_nin: [String]
+    paragraph_exists: Boolean
+    link: CS_LinkWhere
+    link_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+}
+
+type CS_InformationPage {
+    title: String
+    display_title: String
+    category_id: [Float]
+    circle_heroConnection: CS_InformationPageCircleHeroConnection
+    middle_slot: [CS_InformationPageMiddleSlot]
+    seo_metadata: CS_SeoMetadata
+    information_page_id: String
+    information_page_url: String
+    system: CS_EntrySystemField
+}
+
+type CS_InformationPageCircleHeroConnection {
+    totalCount: Int
+    edges: [CS_InformationPageCircleHeroEdge]
+}
+
+type CS_InformationPageCircleHeroEdge {
+    node: CS_InformationPageCircleHeroNode
+}
+
+union CS_InformationPageCircleHeroNode = CS_CircleHero
+
+input CS_InformationPageCircleHeroWhere {
+    circle_hero: CS_CircleHeroWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+union CS_InformationPageMiddleSlot = CS_InformationPageMiddleSlotTextSnippet | CS_InformationPageMiddleSlotVideo | CS_InformationPageMiddleSlotInformationCards | CS_InformationPageMiddleSlotEditorial | CS_InformationPageMiddleSlotThemeCards | CS_InformationPageMiddleSlotTextImage
+
+type CS_InformationPageMiddleSlotEditorial {
+    editorial: CS_Editorial
+}
+
+input CS_InformationPageMiddleSlotEditorialWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_position: String
+    image_position_ne: String
+    image_position_in: [String]
+    image_position_nin: [String]
+    image_position_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    primary_link: CS_LinkWhere
+    primary_link_exists: Boolean
+    secondary_link: CS_LinkWhere
+    secondary_link_exists: Boolean
+}
+
+type CS_InformationPageMiddleSlotInformationCards {
+    information_cards: CS_InformationCards
+}
+
+input CS_InformationPageMiddleSlotInformationCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    cards: CS_InformationCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_InformationPageMiddleSlotTextImage {
+    text_image: CS_TextImage
+}
+
+input CS_InformationPageMiddleSlotTextImageWhere {
+    text: JSON
+    text_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_position: String
+    image_position_ne: String
+    image_position_in: [String]
+    image_position_nin: [String]
+    image_position_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    link: CS_TextImageLinkWhere
+    link_exists: Boolean
+}
+
+type CS_InformationPageMiddleSlotTextSnippet {
+    text_snippet: CS_TextSnippet
+}
+
+input CS_InformationPageMiddleSlotTextSnippetWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: JSON
+    text_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+}
+
+type CS_InformationPageMiddleSlotThemeCards {
+    theme_cards: CS_ThemeCards
+}
+
+input CS_InformationPageMiddleSlotThemeCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    cards: CS_ThemeCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_InformationPageMiddleSlotVideo {
+    video: CS_Video
+}
+
+input CS_InformationPageMiddleSlotVideoWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    video: CS_SysAssetWhere
+    video_exists: Boolean
+    autoplay: Boolean
+    autoplay_exists: Boolean
+    autoplay_ne: Boolean
+    thumbnail: CS_SysAssetWhere
+    thumbnail_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+}
+
+input CS_InformationPageMiddleSlotWhere {
+    text_snippet: CS_InformationPageMiddleSlotTextSnippetWhere
+    text_snippet_exists: Boolean
+    video: CS_InformationPageMiddleSlotVideoWhere
+    video_exists: Boolean
+    information_cards: CS_InformationPageMiddleSlotInformationCardsWhere
+    information_cards_exists: Boolean
+    editorial: CS_InformationPageMiddleSlotEditorialWhere
+    editorial_exists: Boolean
+    theme_cards: CS_InformationPageMiddleSlotThemeCardsWhere
+    theme_cards_exists: Boolean
+    text_image: CS_InformationPageMiddleSlotTextImageWhere
+    text_image_exists: Boolean
+}
+
+enum CS_InformationPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_InformationPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    category_id: Float
+    category_id_in: [Float]
+    category_id_nin: [Float]
+    category_id_exists: Boolean
+    category_id_ne: Float
+    category_id_lt: Float
+    category_id_lte: Float
+    category_id_gt: Float
+    category_id_gte: Float
+    circle_hero: CS_InformationPageCircleHeroWhere
+    circle_hero_exists: Boolean
+    middle_slot: CS_InformationPageMiddleSlotWhere
+    middle_slot_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    information_page_id: String
+    information_page_id_ne: String
+    information_page_id_in: [String]
+    information_page_id_nin: [String]
+    information_page_id_exists: Boolean
+    information_page_url: String
+    information_page_url_ne: String
+    information_page_url_in: [String]
+    information_page_url_nin: [String]
+    information_page_url_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_InformationPageWhere]
+    OR: [CS_InformationPageWhere]
+}
+
+type CS_JumpstationCards {
+    title: String
+    background_color: String
+    cards: [CS_JumpstationCardsCards]
+}
+
+type CS_JumpstationCardsCards {
+    title: String
+    imageConnection: CS_SysAssetConnection
+    category_link: String
+    links: [CS_Link]
+    all_items_text: String
+}
+
+input CS_JumpstationCardsCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    category_link: String
+    category_link_ne: String
+    category_link_in: [String]
+    category_link_nin: [String]
+    category_link_exists: Boolean
+    links: CS_LinkWhere
+    links_exists: Boolean
+    all_items_text: String
+    all_items_text_ne: String
+    all_items_text_in: [String]
+    all_items_text_nin: [String]
+    all_items_text_exists: Boolean
+}
+
+type CS_LegalArticle {
+    title: String
+    display_title: String
+    json_content: CS_LegalArticleJsonContent
+    system: CS_EntrySystemField
+}
+
+type CS_LegalArticleJsonContent {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_LegalArticleJsonContentEmbeddedItemsConnection
+}
+
+type CS_LegalArticleJsonContentEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_LegalArticleJsonContentEmbeddedItemsEdge]
+}
+
+type CS_LegalArticleJsonContentEmbeddedItemsEdge {
+    node: CS_LegalArticleJsonContentEmbeddedItemsNode
+}
+
+union CS_LegalArticleJsonContentEmbeddedItemsNode = CS_SysAsset
+
+enum CS_LegalArticleOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_LegalArticleWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    json_content: JSON
+    json_content_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_LegalArticleWhere]
+    OR: [CS_LegalArticleWhere]
+}
+
+type CS_LegalOverviewPage {
+    title: String
+    url: String
+    display_title: String
+    terms_sections: [CS_LegalTermsSection]
+    seo_metadata: CS_SeoMetadata
+    translation_options: CS_LegalOverviewPageTranslationOptions
+    system: CS_EntrySystemField
+}
+
+enum CS_LegalOverviewPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_LegalOverviewPageTranslationOptions {
+    fields_to_translate: [String]
+}
+
+input CS_LegalOverviewPageTranslationOptionsWhere {
+    fields_to_translate: String
+    fields_to_translate_ne: String
+    fields_to_translate_in: [String]
+    fields_to_translate_nin: [String]
+    fields_to_translate_exists: Boolean
+}
+
+input CS_LegalOverviewPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    terms_sections: CS_LegalTermsSectionWhere
+    terms_sections_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    translation_options: CS_LegalOverviewPageTranslationOptionsWhere
+    translation_options_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_LegalOverviewPageWhere]
+    OR: [CS_LegalOverviewPageWhere]
+}
+
+type CS_LegalPage {
+    title: String
+    url: String
+    display_title: String
+    intro: String
+    articlesConnection(skip: Int = 0, limit: Int = 100): CS_LegalPageArticlesConnection
+    seo_metadata: CS_SeoMetadata
+    translation_options: CS_LegalPageTranslationOptions
+    system: CS_EntrySystemField
+}
+
+type CS_LegalPageArticlesConnection {
+    totalCount: Int
+    edges: [CS_LegalPageArticlesEdge]
+}
+
+type CS_LegalPageArticlesEdge {
+    node: CS_LegalPageArticlesNode
+}
+
+union CS_LegalPageArticlesNode = CS_LegalArticle
+
+input CS_LegalPageArticlesWhere {
+    legal_article: CS_LegalArticleWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+enum CS_LegalPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_LegalPageTranslationOptions {
+    fields_to_translate: [String]
+}
+
+input CS_LegalPageTranslationOptionsWhere {
+    fields_to_translate: String
+    fields_to_translate_ne: String
+    fields_to_translate_in: [String]
+    fields_to_translate_nin: [String]
+    fields_to_translate_exists: Boolean
+}
+
+input CS_LegalPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    intro: String
+    intro_ne: String
+    intro_in: [String]
+    intro_nin: [String]
+    intro_exists: Boolean
+    articles: CS_LegalPageArticlesWhere
+    articles_count: Int
+    articles_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    translation_options: CS_LegalPageTranslationOptionsWhere
+    translation_options_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_LegalPageWhere]
+    OR: [CS_LegalPageWhere]
+}
+
+type CS_LegalTermsSection {
+    title: String
+    itemsConnection(skip: Int = 0, limit: Int = 100): CS_LegalTermsSectionItemsConnection
+}
+
+type CS_LegalTermsSectionItemsConnection {
+    totalCount: Int
+    edges: [CS_LegalTermsSectionItemsEdge]
+}
+
+type CS_LegalTermsSectionItemsEdge {
+    node: CS_LegalTermsSectionItemsNode
+}
+
+union CS_LegalTermsSectionItemsNode = CS_LegalPage
+
+input CS_LegalTermsSectionItemsWhere {
+    legal_page: CS_LegalPageWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+input CS_LegalTermsSectionWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    items: CS_LegalTermsSectionItemsWhere
+    items_count: Int
+    items_exists: Boolean
+}
+
+type CS_Link {
+    title: String
+    href: String
+}
+
+input CS_LinkWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    href: String
+    href_ne: String
+    href_in: [String]
+    href_nin: [String]
+    href_exists: Boolean
+}
+
+type CS_MarketingMenu {
+    title: String
+    items: [CS_MarketingMenuItems]
+    flagship_link: CS_MarketingMenuFlagshipLink
+    system: CS_EntrySystemField
+}
+
+type CS_MarketingMenuFlagshipLink {
+    title: String
+    subtitle: String
+    url: String
+    text_color: String
+}
+
+input CS_MarketingMenuFlagshipLinkWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    text_color: String
+    text_color_ne: String
+    text_color_in: [String]
+    text_color_nin: [String]
+    text_color_exists: Boolean
+}
+
+type CS_MarketingMenuItems {
+    title: String
+    url: String
+}
+
+input CS_MarketingMenuItemsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+}
+
+enum CS_MarketingMenuOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_MarketingMenuWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    items: CS_MarketingMenuItemsWhere
+    items_exists: Boolean
+    flagship_link: CS_MarketingMenuFlagshipLinkWhere
+    flagship_link_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_MarketingMenuWhere]
+    OR: [CS_MarketingMenuWhere]
+}
+
+type CS_MediaCard {
+    imageConnection: CS_SysAssetConnection
+    title: String
+    subtitle: String
+    image_ratio: String
+    url: String
+    background_color: JSON
+}
+
+input CS_MediaCardWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+}
+
+type CS_MenuTabs {
+    title: String
+    dropdown_name: String
+    show_disclaimer: Boolean
+    category: [CS_MenuTabsCategory]
+    system: CS_EntrySystemField
+}
+
+type CS_MenuTabsCategory {
+    title: String
+    url: String
+    item: [CS_MenuTabsCategoryItem]
+}
+
+type CS_MenuTabsCategoryItem {
+    title: String
+    url: String
+}
+
+input CS_MenuTabsCategoryItemWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+}
+
+input CS_MenuTabsCategoryWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    item: CS_MenuTabsCategoryItemWhere
+    item_exists: Boolean
+}
+
+enum CS_MenuTabsOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_MenuTabsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    dropdown_name: String
+    dropdown_name_ne: String
+    dropdown_name_in: [String]
+    dropdown_name_nin: [String]
+    dropdown_name_exists: Boolean
+    show_disclaimer: Boolean
+    show_disclaimer_exists: Boolean
+    show_disclaimer_ne: Boolean
+    category: CS_MenuTabsCategoryWhere
+    category_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_MenuTabsWhere]
+    OR: [CS_MenuTabsWhere]
+}
+
+type CS_MhpTopBanner {
+    title: String
+    display_title: String
+    banner_subtitle: String
+    url: String
+    background_color: JSON
+    show_special_campaign: Boolean
+    special_campaign_image: CS_MhpTopBannerSpecialCampaignImage
+    banner_image: CS_MhpTopBannerBannerImage
+    system: CS_EntrySystemField
+}
+
+type CS_MhpTopBannerBannerImage {
+    imageConnection: CS_SysAssetConnection
+    button_text: String
+}
+
+input CS_MhpTopBannerBannerImageWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    button_text: String
+    button_text_ne: String
+    button_text_in: [String]
+    button_text_nin: [String]
+    button_text_exists: Boolean
+}
+
+enum CS_MhpTopBannerOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_MhpTopBannerSpecialCampaignImage {
+    desktop_image_webConnection: CS_SysAssetConnection
+    mobile_image_webConnection: CS_SysAssetConnection
+    app_imageConnection: CS_SysAssetConnection
+}
+
+input CS_MhpTopBannerSpecialCampaignImageWhere {
+    desktop_image_web: CS_SysAssetWhere
+    desktop_image_web_exists: Boolean
+    mobile_image_web: CS_SysAssetWhere
+    mobile_image_web_exists: Boolean
+    app_image: CS_SysAssetWhere
+    app_image_exists: Boolean
+}
+
+input CS_MhpTopBannerWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    banner_subtitle: String
+    banner_subtitle_ne: String
+    banner_subtitle_in: [String]
+    banner_subtitle_nin: [String]
+    banner_subtitle_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    show_special_campaign: Boolean
+    show_special_campaign_exists: Boolean
+    show_special_campaign_ne: Boolean
+    special_campaign_image: CS_MhpTopBannerSpecialCampaignImageWhere
+    special_campaign_image_exists: Boolean
+    banner_image: CS_MhpTopBannerBannerImageWhere
+    banner_image_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_MhpTopBannerWhere]
+    OR: [CS_MhpTopBannerWhere]
+}
+
+type CS_PartyCards {
+    title: String
+    subtitle: String
+    display_mode: String
+    hide_titles: Boolean
+    sponsored: Boolean
+    cards: [CS_PartyCardsCards]
+}
+
+type CS_PartyCardsCards {
+    imageConnection: CS_SysAssetConnection
+    image_border: Boolean
+    title: String
+    subtitle: String
+    url: String
+}
+
+input CS_PartyCardsCardsWhere {
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_border: Boolean
+    image_border_exists: Boolean
+    image_border_ne: Boolean
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+}
+
+input CS_PartyCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    hide_titles: Boolean
+    hide_titles_exists: Boolean
+    hide_titles_ne: Boolean
+    sponsored: Boolean
+    sponsored_exists: Boolean
+    sponsored_ne: Boolean
+    cards: CS_PartyCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_ProductCarousel {
+    title: String
+    subtitle: String
+    background_color: JSON
+    products: [CS_ProductCarouselProducts]
+}
+
+type CS_ProductCarouselProducts {
+    global_id: String
+    product: Product
+}
+
+input CS_ProductCarouselProductsWhere {
+    global_id: String
+    global_id_ne: String
+    global_id_in: [String]
+    global_id_nin: [String]
+    global_id_exists: Boolean
+}
+
+input CS_ProductCarouselWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    products: CS_ProductCarouselProductsWhere
+    products_exists: Boolean
+}
+
+"""
+The CS_SeoMetadata type below contains SEO fields that are managed on the side of content stack, but used by TRC's subgraph in order to return SeoMetadata NOTE: This solution is temporary. In the future we want to have SEO business maintain the SEO fields for content stack pages in SEO Wizard Once we have support for this, the CS_SeoMetadata type in the CS_Proxy and TRC subgraphs should get deprecated
+"""
+type CS_SeoMetadata {
+    title: String
+    description: String
+    no_index: Boolean
+    no_follow: Boolean
+    canonical_url: String
+    lang: String
+}
+
+input CS_SeoMetadataWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    description: String
+    description_ne: String
+    description_in: [String]
+    description_nin: [String]
+    description_exists: Boolean
+    no_index: Boolean
+    no_index_exists: Boolean
+    no_index_ne: Boolean
+    no_follow: Boolean
+    no_follow_exists: Boolean
+    no_follow_ne: Boolean
+    canonical_url: String
+    canonical_url_ne: String
+    canonical_url_in: [String]
+    canonical_url_nin: [String]
+    canonical_url_exists: Boolean
+    lang: String
+    lang_ne: String
+    lang_in: [String]
+    lang_nin: [String]
+    lang_exists: Boolean
+}
+
+type CS_SizeGuide {
+    title: String
+    chunk_id: [Float]
+    party_id: [Float]
+    distinctive_feature: String
+    attribute_id: String
+    measuring_content: [CS_SizeGuideMeasuringContent]
+    system: CS_EntrySystemField
+}
+
+type CS_SizeGuideMeasuringContent {
+    title: String
+    attribute_value: [Float]
+    text: String
+    image_title: String
+    imageConnection: CS_SysAssetConnection
+    size_guide_table: String
+}
+
+input CS_SizeGuideMeasuringContentWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    attribute_value: Float
+    attribute_value_in: [Float]
+    attribute_value_nin: [Float]
+    attribute_value_exists: Boolean
+    attribute_value_ne: Float
+    attribute_value_lt: Float
+    attribute_value_lte: Float
+    attribute_value_gt: Float
+    attribute_value_gte: Float
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    image_title: String
+    image_title_ne: String
+    image_title_in: [String]
+    image_title_nin: [String]
+    image_title_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    size_guide_table: String
+    size_guide_table_ne: String
+    size_guide_table_in: [String]
+    size_guide_table_nin: [String]
+    size_guide_table_exists: Boolean
+}
+
+enum CS_SizeGuideOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+input CS_SizeGuideWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    chunk_id: Float
+    chunk_id_in: [Float]
+    chunk_id_nin: [Float]
+    chunk_id_exists: Boolean
+    chunk_id_ne: Float
+    chunk_id_lt: Float
+    chunk_id_lte: Float
+    chunk_id_gt: Float
+    chunk_id_gte: Float
+    party_id: Float
+    party_id_in: [Float]
+    party_id_nin: [Float]
+    party_id_exists: Boolean
+    party_id_ne: Float
+    party_id_lt: Float
+    party_id_lte: Float
+    party_id_gt: Float
+    party_id_gte: Float
+    distinctive_feature: String
+    distinctive_feature_ne: String
+    distinctive_feature_in: [String]
+    distinctive_feature_nin: [String]
+    distinctive_feature_exists: Boolean
+    attribute_id: String
+    attribute_id_ne: String
+    attribute_id_in: [String]
+    attribute_id_nin: [String]
+    attribute_id_exists: Boolean
+    measuring_content: CS_SizeGuideMeasuringContentWhere
+    measuring_content_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_SizeGuideWhere]
+    OR: [CS_SizeGuideWhere]
+}
+
+type CS_StorefrontPage {
+    """The title of the store front page. This field serves as the key"""
+    title: String
+    display_title: String
+    category_id: Float
+    circle_heroConnection: CS_StorefrontPageCircleHeroConnection
+    middle_slot: [CS_StorefrontPageMiddleSlot]
+    seo_snippet: CS_StorefrontPageSeoSnippet
+    seo_metadata: CS_SeoMetadata
+    system: CS_EntrySystemField
+    """
+    The seoMetadata that TRC provides when a CS_StorefrontPage is fetched through the Shop API
+    """
+    seoMetadata(canonicalParameters: SeoCanonicalParameters!): SeoMetadata
+}
+
+type CS_StorefrontPageCircleHeroConnection {
+    totalCount: Int
+    edges: [CS_StorefrontPageCircleHeroEdge]
+}
+
+type CS_StorefrontPageCircleHeroEdge {
+    node: CS_StorefrontPageCircleHeroNode
+}
+
+union CS_StorefrontPageCircleHeroNode = CS_CircleHero
+
+input CS_StorefrontPageCircleHeroWhere {
+    circle_hero: CS_CircleHeroWhere
+    MATCH: CS_EvalReferenceEnum
+}
+
+union CS_StorefrontPageMiddleSlot = CS_StorefrontPageMiddleSlotJumpstationCards | CS_StorefrontPageMiddleSlotCategoryNavigation | CS_StorefrontPageMiddleSlotThemeCards | CS_StorefrontPageMiddleSlotEditorial | CS_StorefrontPageMiddleSlotTextSnippet | CS_StorefrontPageMiddleSlotPartyCards | CS_StorefrontPageMiddleSlotProductCarousel | CS_StorefrontPageMiddleSlotInformationCards | CS_StorefrontPageMiddleSlotVideo
+
+type CS_StorefrontPageMiddleSlotCategoryNavigation {
+    category_navigation: CS_CategoryNavigation
+}
+
+input CS_StorefrontPageMiddleSlotCategoryNavigationWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    links: CS_LinkWhere
+    links_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotEditorial {
+    editorial: CS_Editorial
+}
+
+input CS_StorefrontPageMiddleSlotEditorialWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    image_position: String
+    image_position_ne: String
+    image_position_in: [String]
+    image_position_nin: [String]
+    image_position_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    primary_link: CS_LinkWhere
+    primary_link_exists: Boolean
+    secondary_link: CS_LinkWhere
+    secondary_link_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotInformationCards {
+    information_cards: CS_InformationCards
+}
+
+input CS_StorefrontPageMiddleSlotInformationCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    cards: CS_InformationCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotJumpstationCards {
+    jumpstation_cards: CS_JumpstationCards
+}
+
+input CS_StorefrontPageMiddleSlotJumpstationCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    cards: CS_JumpstationCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotPartyCards {
+    party_cards: CS_PartyCards
+}
+
+input CS_StorefrontPageMiddleSlotPartyCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    hide_titles: Boolean
+    hide_titles_exists: Boolean
+    hide_titles_ne: Boolean
+    sponsored: Boolean
+    sponsored_exists: Boolean
+    sponsored_ne: Boolean
+    cards: CS_PartyCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotProductCarousel {
+    product_carousel: CS_ProductCarousel
+}
+
+input CS_StorefrontPageMiddleSlotProductCarouselWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    products: CS_ProductCarouselProductsWhere
+    products_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotTextSnippet {
+    text_snippet: CS_TextSnippet
+}
+
+input CS_StorefrontPageMiddleSlotTextSnippetWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    text: JSON
+    text_exists: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotThemeCards {
+    theme_cards: CS_ThemeCards
+}
+
+input CS_StorefrontPageMiddleSlotThemeCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    cards: CS_ThemeCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_StorefrontPageMiddleSlotVideo {
+    video: CS_Video
+}
+
+input CS_StorefrontPageMiddleSlotVideoWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    background_color: JSON
+    background_color_exists: Boolean
+    video: CS_SysAssetWhere
+    video_exists: Boolean
+    autoplay: Boolean
+    autoplay_exists: Boolean
+    autoplay_ne: Boolean
+    thumbnail: CS_SysAssetWhere
+    thumbnail_exists: Boolean
+    text: String
+    text_ne: String
+    text_in: [String]
+    text_nin: [String]
+    text_exists: Boolean
+    url: CS_LinkWhere
+    url_exists: Boolean
+}
+
+input CS_StorefrontPageMiddleSlotWhere {
+    jumpstation_cards: CS_StorefrontPageMiddleSlotJumpstationCardsWhere
+    jumpstation_cards_exists: Boolean
+    category_navigation: CS_StorefrontPageMiddleSlotCategoryNavigationWhere
+    category_navigation_exists: Boolean
+    theme_cards: CS_StorefrontPageMiddleSlotThemeCardsWhere
+    theme_cards_exists: Boolean
+    editorial: CS_StorefrontPageMiddleSlotEditorialWhere
+    editorial_exists: Boolean
+    text_snippet: CS_StorefrontPageMiddleSlotTextSnippetWhere
+    text_snippet_exists: Boolean
+    party_cards: CS_StorefrontPageMiddleSlotPartyCardsWhere
+    party_cards_exists: Boolean
+    product_carousel: CS_StorefrontPageMiddleSlotProductCarouselWhere
+    product_carousel_exists: Boolean
+    information_cards: CS_StorefrontPageMiddleSlotInformationCardsWhere
+    information_cards_exists: Boolean
+    video: CS_StorefrontPageMiddleSlotVideoWhere
+    video_exists: Boolean
+}
+
+enum CS_StorefrontPageOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+type CS_StorefrontPageSeoSnippet {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_StorefrontPageSeoSnippetEmbeddedItemsConnection
+}
+
+type CS_StorefrontPageSeoSnippetEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_StorefrontPageSeoSnippetEmbeddedItemsEdge]
+}
+
+type CS_StorefrontPageSeoSnippetEmbeddedItemsEdge {
+    node: CS_StorefrontPageSeoSnippetEmbeddedItemsNode
+}
+
+union CS_StorefrontPageSeoSnippetEmbeddedItemsNode = CS_SysAsset
+
+input CS_StorefrontPageWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    display_title: String
+    display_title_ne: String
+    display_title_in: [String]
+    display_title_nin: [String]
+    display_title_exists: Boolean
+    category_id: Float
+    category_id_in: [Float]
+    category_id_nin: [Float]
+    category_id_exists: Boolean
+    category_id_ne: Float
+    category_id_lt: Float
+    category_id_lte: Float
+    category_id_gt: Float
+    category_id_gte: Float
+    circle_hero: CS_StorefrontPageCircleHeroWhere
+    circle_hero_exists: Boolean
+    middle_slot: CS_StorefrontPageMiddleSlotWhere
+    middle_slot_exists: Boolean
+    seo_snippet: JSON
+    seo_snippet_exists: Boolean
+    seo_metadata: CS_SeoMetadataWhere
+    seo_metadata_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_by: String
+    created_by_in: [String]
+    created_by_nin: [String]
+    created_by_ne: String
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_by: String
+    updated_by_in: [String]
+    updated_by_nin: [String]
+    updated_by_ne: String
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+    locale_exists: Boolean
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    tags_in: [String]
+    tags_nin: [String]
+    version: Int
+    version_ne: Int
+    version_in: [Int]
+    version_nin: [Int]
+    version_lt: Int
+    version_lte: Int
+    version_gt: Int
+    version_gte: Int
+    publish_details: CS_SystemPublishDetailsWhere
+    AND: [CS_StorefrontPageWhere]
+    OR: [CS_StorefrontPageWhere]
+}
+
+type CS_SysAsset {
+    title: String
+    url(
+        """
+        Contentstack Image Delivery API is used to retrieve, manipulate and/or convert image files of your Contentstack account and deliver it to your web or mobile properties
+        """
+        transform: CS_SysAssetTransformUrl
+    ): String
+    content_type: String
+    filename: String
+    file_size: Int
+    description: String
+    dimension: CS_SysAssetDimension
+    metadata: JSON
+    unique_identifier: String
+    system: CS_SysAssetSystemField
+}
+
+"""WEBP images are usually lower in size and have good quality."""
+enum CS_SysAssetAutoValues {
+    WEBP
+}
+
+type CS_SysAssetConnection {
+    totalCount: Int
+    edges: [CS_SysAssetEdge]
+}
+
+type CS_SysAssetDimension {
+    width: Int
+    height: Int
+}
+
+input CS_SysAssetDimensionWhere {
+    width: Int
+    width_ne: Int
+    width_in: [Int]
+    width_nin: [Int]
+    width_exists: Boolean
+    width_lt: Int
+    width_lte: Int
+    width_gt: Int
+    width_gte: Int
+    height: Int
+    height_ne: Int
+    height_in: [Int]
+    height_nin: [Int]
+    height_exists: Boolean
+    height_lt: Int
+    height_lte: Int
+    height_gt: Int
+    height_gte: Int
+}
+
+enum CS_SysAssetDisableValues {
+    """
+    UPSCALE is always enabled, in which the image is upscaled if the output image (by specifying the width or height) is bigger than the source image
+    """
+    UPSCALE
+}
+
+"""This parameter allows an image to be downloaded or rendered on page"""
+enum CS_SysAssetDispositionValues {
+    """Allows to download an image"""
+    ATTACHMENT
+    """Allows an image to be rendered on page"""
+    INLINE
+}
+
+type CS_SysAssetEdge {
+    node: CS_SysAsset
+}
+
+enum CS_SysAssetFitValues {
+    BOUNDS
+    CROP
+}
+
+enum CS_SysAssetImageFormats {
+    """Convert an image to GIF format"""
+    GIF
+    """Convert an image to PNG format"""
+    PNG
+    """Convert an image to JPEG format"""
+    JPG
+    """
+    A Progressive JPEG is an image file created using a compression method that displays higher detail in progression
+    """
+    PJPG
+    """WEBP images are usually lower in size and have good quality"""
+    WEBP
+    """WEBP Lossless format"""
+    WEBPLL
+    """WEBP Lossy format"""
+    WEBPLY
+}
+
+enum CS_SysAssetOrderBy {
+    created_at_ASC
+    created_at_DESC
+    updated_at_ASC
+    updated_at_DESC
+}
+
+enum CS_SysAssetOrientValues {
+    """Set image to default"""
+    DEFAULT
+    """Flip image horizontally"""
+    HORIZONTALLY
+    """Flip image horizontally and vertically"""
+    BOTH
+    """Flip image vertically"""
+    VERTICALLY
+    """Flip image horizontally and then rotate 90 degrees towards left"""
+    ROTATE90LEFT
+    """Rotate image 90 degrees towards right"""
+    ROTATE90RIGHT
+}
+
+"""
+The overlay_align parameter allows you to put one image on top of another
+"""
+enum CS_SysAssetOverlayAlignValues {
+    """Align the overlay image to the top of the actual image"""
+    TOP
+    """Align the overlay image to the bottom of the actual image"""
+    BOTTOM
+    """Align the overlay image to the left of the actual image"""
+    LEFT
+    """Align the overlay image to the right of the actual image"""
+    RIGHT
+    """Align the overlay image to the middle (vertically) of the actual image"""
+    MIDDLE
+    """
+    Align the overlay image to the center (horizontally) of the actual image
+    """
+    CENTER
+}
+
+enum CS_SysAssetOverlayRepeatValues {
+    """Horizontal repetition"""
+    X
+    """Vertical repetition"""
+    Y
+    """Horizontal and vertical repetition"""
+    BOTH
+}
+
+type CS_SysAssetSystemField {
+    branch: String
+    created_at: DateTime
+    updated_at: DateTime
+    created_by: String
+    updated_by: String
+    uid: String
+    tags: [String]
+    version: Int
+    content_type_uid: String
+    publish_details: CS_SystemPublishDetails
+    extensionConnection(skip: Int = 0, limit: Int = 25): CS_SysExtensionConnection
+}
+
+input CS_SysAssetTransformUrl {
+    height: String
+    width: String
+    """
+    Format parameter lets you converts a given image from one format to another
+    """
+    format: CS_SysAssetImageFormats
+    """
+    The disable parameter disables the functionality that is enabled by default
+    """
+    disable: CS_SysAssetDisableValues
+    """
+    Fit parameter enables you to fit the given image properly within the specified height and width
+    """
+    fit: CS_SysAssetFitValues
+    quality: Int
+    crop: String
+    trim: String
+    """
+    The orient parameter lets you control the cardinal orientation of the given image
+    """
+    orient: CS_SysAssetOrientValues
+    overlay: String
+    overlay_align: CS_SysAssetOverlayAlignValues
+    """
+    The overlay_repeat parameter lets you define how the overlay image will be repeated on the given image
+    """
+    overlay_repeat: CS_SysAssetOverlayRepeatValues
+    """
+    When the auto parameter is set to webp, it enables WebP image support. WebP images have higher compression rate with minimum loss of quality.
+    """
+    auto: CS_SysAssetAutoValues
+    """The disposition parameter lets you allow image to download or render."""
+    disposition: CS_SysAssetDispositionValues
+    """
+    The dpr parameter lets you deliver images with appropriate size to devices that come with a defined device pixel ratio. The device pixel ratio of any device determines the screen resolution that its CSS would interpret
+    """
+    dpr: String
+    """
+    The bg-color parameter lets you set a backgroud color for the given image. This is useful when applying padding or for replacing the transparent pixels of an image
+    """
+    bg_color: String
+    """
+    This parameter lets you add extra pixels to the edges of an image. You can specify values for top, right, bottom, and left padding for an image
+    """
+    pad: String
+    """
+    The value for this parameter can be set in pixels or percentage. For pixel value, use any whole number between 1 and 8192. For percentage value, use any decimal number between 0.0 and 0.99. When height is defined in percentage, it relative to the output image
+    """
+    overlay_height: String
+    """
+    The value for this parameter can be set in pixels or percentage. For pixel value, use any whole number between 1 and 8192. For percentage value, use any decimal number between 0.0 and 0.99. When width is defined in percentage, it is relative to the output image
+    """
+    overlay_width: String
+}
+
+input CS_SysAssetWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    filename: String
+    filename_ne: String
+    filename_in: [String]
+    filename_nin: [String]
+    filename_exists: Boolean
+    description: String
+    description_ne: String
+    description_in: [String]
+    description_nin: [String]
+    description_exists: Boolean
+    created_at: DateTime
+    created_at_in: [DateTime]
+    created_at_nin: [DateTime]
+    created_at_ne: DateTime
+    created_at_lt: DateTime
+    created_at_lte: DateTime
+    created_at_gt: DateTime
+    created_at_gte: DateTime
+    updated_at: DateTime
+    updated_at_in: [DateTime]
+    updated_at_nin: [DateTime]
+    updated_at_ne: DateTime
+    updated_at_lt: DateTime
+    updated_at_lte: DateTime
+    updated_at_gt: DateTime
+    updated_at_gte: DateTime
+    uid: String
+    uid_ne: String
+    uid_in: [String]
+    uid_nin: [String]
+    uid_exists: Boolean
+    file_size: Int
+    file_size_ne: Int
+    file_size_in: [Int]
+    file_size_nin: [Int]
+    file_size_exists: Boolean
+    file_size_lt: Int
+    file_size_lte: Int
+    file_size_gt: Int
+    file_size_gte: Int
+    dimension_exists: Boolean
+    dimension: CS_SysAssetDimensionWhere
+    tags: String
+    tags_in: [String]
+    tags_nin: [String]
+    AND: [CS_SysAssetWhere]
+    OR: [CS_SysAssetWhere]
+}
+
+type CS_SysExtensionConnection {
+    totalCount: Int
+    edges: [CS_SysExtensionEdge]
+}
+
+type CS_SysExtensionEdge {
+    node: CS_SysMetadata
+}
+
+type CS_SysMetadata {
+    metadata: [JSON]
+    extension_uid: String
+}
+
+type CS_SystemPublishDetails {
+    environment: String
+    locale: String
+    time: DateTime
+    user: String
+}
+
+input CS_SystemPublishDetailsWhere {
+    time: DateTime
+    time_ne: DateTime
+    time_in: [DateTime]
+    time_nin: [DateTime]
+    time_lt: DateTime
+    time_lte: DateTime
+    time_gt: DateTime
+    time_gte: DateTime
+    user: String
+    user_ne: String
+    user_in: [String]
+    user_nin: [String]
+    locale: String
+    locale_ne: String
+    locale_in: [String]
+    locale_nin: [String]
+}
+
+type CS_TextImage {
+    text: CS_TextImageText
+    imageConnection: CS_SysAssetConnection
+    image_position: String
+    image_ratio: String
+    background_color: String
+    link: [CS_TextImageLink]
+}
+
+type CS_TextImageLink {
+    title: String
+    url: String
+}
+
+input CS_TextImageLinkWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+}
+
+type CS_TextImageText {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_TextImageTextEmbeddedItemsConnection
+}
+
+type CS_TextImageTextEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_TextImageTextEmbeddedItemsEdge]
+}
+
+type CS_TextImageTextEmbeddedItemsEdge {
+    node: CS_TextImageTextEmbeddedItemsNode
+}
+
+union CS_TextImageTextEmbeddedItemsNode = CS_SysAsset
+
+type CS_TextSnippet {
+    title: String
+    subtitle: String
+    text: CS_TextSnippetText
+    display_mode: String
+    background_color: String
+}
+
+type CS_TextSnippetText {
+    json: JSON
+    embedded_itemsConnection(skip: Int = 0, limit: Int = 100): CS_TextSnippetTextEmbeddedItemsConnection
+}
+
+type CS_TextSnippetTextEmbeddedItemsConnection {
+    totalCount: Int
+    edges: [CS_TextSnippetTextEmbeddedItemsEdge]
+}
+
+type CS_TextSnippetTextEmbeddedItemsEdge {
+    node: CS_TextSnippetTextEmbeddedItemsNode
+}
+
+union CS_TextSnippetTextEmbeddedItemsNode = CS_SysAsset
+
+type CS_ThemeCards {
+    title: String
+    subtitle: String
+    contained: Boolean
+    display_mode: String
+    image_ratio: String
+    background_color: String
+    background_color_v2: JSON
+    cards: [CS_ThemeCardsCards]
+}
+
+type CS_ThemeCardsCards {
+    title: String
+    subtitle: String
+    url: String
+    imageConnection: CS_SysAssetConnection
+    background_color: String
+    background_color_v2: JSON
+}
+
+input CS_ThemeCardsCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    url: String
+    url_ne: String
+    url_in: [String]
+    url_nin: [String]
+    url_exists: Boolean
+    image: CS_SysAssetWhere
+    image_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+}
+
+input CS_ThemeCardsWhere {
+    title: String
+    title_ne: String
+    title_in: [String]
+    title_nin: [String]
+    title_exists: Boolean
+    subtitle: String
+    subtitle_ne: String
+    subtitle_in: [String]
+    subtitle_nin: [String]
+    subtitle_exists: Boolean
+    contained: Boolean
+    contained_exists: Boolean
+    contained_ne: Boolean
+    display_mode: String
+    display_mode_ne: String
+    display_mode_in: [String]
+    display_mode_nin: [String]
+    display_mode_exists: Boolean
+    image_ratio: String
+    image_ratio_ne: String
+    image_ratio_in: [String]
+    image_ratio_nin: [String]
+    image_ratio_exists: Boolean
+    background_color: String
+    background_color_ne: String
+    background_color_in: [String]
+    background_color_nin: [String]
+    background_color_exists: Boolean
+    background_color_v2: JSON
+    background_color_v2_exists: Boolean
+    cards: CS_ThemeCardsCardsWhere
+    cards_exists: Boolean
+}
+
+type CS_Video {
+    title: String
+    subtitle: String
+    background_color: JSON
+    videoConnection: CS_SysAssetConnection
+    autoplay: Boolean
+    thumbnailConnection: CS_SysAssetConnection
+    text: String
+    url: CS_Link
+}
+
+"""Customer Entity"""
+interface Customer {
+    notUsed: Boolean! @deprecated(reason: "Do not use this field")
+    """Deals grouped by brand"""
+    brandDeals: [BrandDeals!]
+    """
+    Returns Top Deals (Promotional feed) with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    promotionalFeed: ProductConnection
+    """
+    Returns New for You with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    newForYou: ProductConnection
+    """
+    Returns Top Picks with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    topPicks: ProductConnection
+    """
+    Returns Brands with list of personalized brand items per unique customer (if logged in/ recognised and consent given, else fallback popular brand items)
+    """
+    favoriteBrands: BrandConnection @deprecated(reason: "Use brandsDeals query instead")
+    """Recently viewed items for this customer"""
+    recentlyViewed: ProductConnection
+    """
+    Product (root)categories, sorted based on importance, personalised if a customer is known
+    """
+    productCategories: ProductCategoryConnection
+    """Favorite shelves are sub categories and can have children"""
+    favoriteShelves: ProductCategoryConnection
+}
+
+"""The different types of CustomerServicePages"""
+enum CustomerServicePage {
+    """Order Customer Service Pages Type"""
+    ORDER
+    """Payment Customer Service Pages Type"""
+    PAY
+    """Warranty Customer Service Pages Type"""
+    WARRANTY
+    """Return Customer Service Pages Type"""
+    RETURN
+}
+
+"""Custom link of the promotion card."""
+type CustomLink {
+    """Custom link url."""
+    url: String!
+    """Text of the custom link."""
+    text: String
+}
+
+"""Data sharing consent"""
+type DataSharingConsent {
+    """Consent version"""
+    version: Int!
+    """Flag to check if we should ask for a data sharing consent"""
+    consentRequired: Boolean!
+    """
+    Data sharing preferences, can be null if user didn't provide consent for the version
+    """
+    preferences: DataSharingPreferences
+    """Data sharing labels, could be null if provided unsupported language"""
+    labels: DataSharingLabels
+}
+
+"""Set data sharing consent"""
+input DataSharingInput {
+    """Consent to share data with Ahold Delhaize companies"""
+    dataSharing: Boolean!
+}
+
+"""
+Data sharing labels, usually all of the labels will be present, but design could change and that could cause a label's rework
+"""
+type DataSharingLabels {
+    """Title"""
+    modalTitle: String
+    """Content"""
+    modalContent: String
+    """Only in settings - checkbox description"""
+    modalCheckboxDescription: String
+    """Accept all button"""
+    modalAcceptButton: String
+    """Deny all button"""
+    modalDenyButton: String
+    """Only in settings - save selected"""
+    modalSaveButton: String
+}
+
+"""Data sharing consent values"""
+type DataSharingPreferences {
+    """
+    If the user gives data usage consent on transactional/declared outside bol.com + accepts the new data sharing consent, bol.com can share the customer data with AH, Etos, G&G and our media entity AD
+    """
+    dataSharing: Boolean!
+}
+
+"""Data usage consent"""
+type DataUsageConsent {
+    """Consent version"""
+    version: Int!
+    """
+    Data usage preferences, can be null if user didn't provide consent for the version
+    """
+    preferences: DataUsagePreferences
+    """Data usage labels, could be null if provided unsupported language"""
+    labels: DataUsageLabels
+}
+
+"""Set data usage consent"""
+input DataUsageInput {
+    """
+    If user gives consent, it means that we can use their transactional / declared data like what products they ordered and their address for personalization in bol.com
+    """
+    internalTransactional: Boolean!
+    """
+    If user gives consent, it means that we can use their transactional / declared data like what products they ordered and their address for personalization outside bol.com
+    """
+    externalTransactional: Boolean!
+    """
+    If user gives consent, it means that we can use their behavioral data like what pages they browsed internally in bol.com for personalization
+    """
+    internalBehavioral: Boolean!
+    """
+    If user gives consent, it means that we can use their behavioral data like what pages they browsed internally outside bol.com for personalization. This is set to false by default if user declines ATT in IOS devices.
+    """
+    externalBehavioral: Boolean!
+}
+
+"""
+Data usage labels, usually all of the labels will be present, but design could change and that could cause a label's rework
+"""
+type DataUsageLabels {
+    """Startup page title"""
+    firstPageTitle: String
+    """Startup page content"""
+    firstPageContent: String
+    """Consent selection page title"""
+    secondPageTitle: String
+    """Consent selection page content"""
+    secondPageContent: String
+    """Consent selection page footer"""
+    secondPageFooter: String
+    """Internal consents block title"""
+    switchInternalTitle: String
+    """Internal consents block description"""
+    switchInternalDescription: String
+    """Internal transactional switch description"""
+    switchInternalTransactionalDescription: String
+    """Internal behavioral switch description"""
+    switchInternalBehavioralDescription: String
+    """External consents block title"""
+    switchExternalTitle: String
+    """External consents block description"""
+    switchExternalDescription: String
+    """External transactional switch description"""
+    switchExternalTransactionalDescription: String
+    """External behavioral switch description"""
+    switchExternalBehavioralDescription: String
+    """iOS ATT additional info"""
+    switchExternalAttAddition: String
+    """Accept all button"""
+    buttonAcceptAll: String
+    """Reject all button"""
+    buttonRejectAll: String
+    """Select consents button"""
+    buttonSelect: String
+    """Accept selected button"""
+    buttonAcceptSelected: String
+}
+
+"""Data usage consent values"""
+type DataUsagePreferences {
+    """
+    If user gives consent, it means that we can use their transactional / declared data like what products they ordered and their address for personalization in bol.com
+    """
+    internalTransactional: Boolean!
+    """
+    If user gives consent, it means that we can use their transactional / declared data like what products they ordered and their address for personalization outside bol.com
+    """
+    externalTransactional: Boolean!
+    """
+    If user gives consent, it means that we can use their behavioral data like what pages they browsed internally in bol.com for personalization
+    """
+    internalBehavioral: Boolean!
+    """
+    If user gives consent, it means that we can use their behavioral data like what pages they browsed internally outside bol.com for personalization. This is set to false by default if user declines ATT in IOS devices.
+    """
+    externalBehavioral: Boolean!
+}
+
+scalar Date @specifiedBy(url: "https://scalars.graphql.org/andimarek/local-date.html")
+
+""" This field accepts both ISODateString and ISODateTimeStringexample: 1992-08-14 or 1992-08-14T03:42:00.000Z
+"""
+scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")
+
+"""Pages for the DayDeal"""
+enum DayDealPage {
+    HOME
+}
+
+interface Deal {
+    """The title of the `Deal`."""
+    title: String!
+    """The title of the `Deal` with Markup language."""
+    markupTitle: String!
+    """The subtitle of the `Deal`."""
+    subtitle: String!
+    """
+    Product reference, intended for showing product information only. For the offer information, use the `offer` field of this `ProductDeal`.
+    """
+    highlightedProduct: Product
+    """The DateTime when the `Deal` ends."""
+    expiresAt: DateTime!
+    """The promoParameter for the link of the `Deal`."""
+    promoParameter: String!
+    """ACM Disclaimer for the `Deal`."""
+    disclaimer: String
+    """The type of the `Deal`"""
+    type: DealType!
+}
+
+"""Enumeration that specifies the possible deal type."""
+enum DealResponseType {
+    """If the response is a product"""
+    PRODUCT_DEAL
+    """If the response is a banner"""
+    BANNER_DEAL
+}
+
+"""The type of deal"""
+enum DealType {
+    DAY_DEAL
+    PRICE_ALARM
+    FLASH_DEAL
+}
+
+input DeleteItemFromLastAddedWishlistInput {
+    """ID of the product to delete from the wishlist"""
+    productId: ID!
+}
+
+union DeleteItemFromLastAddedWishlistResult = WishlistItem | InvalidUserProblem
+
+"""The type of device used by the customer."""
+enum DeviceType {
+    DESKTOP
+    MOBILE
+    TABLET
+    OTHER
+}
+
+"""The calculated discount."""
+type Discount {
+    """The amount saved by discount."""
+    amount: Money!
+    """The percentage saved by discount."""
+    percentage: Int!
+}
+
+"""
+A CMS component which displays a text with a title, subtitle image and two optional links on a page.
+"""
+type Editorial {
+    """Header."""
+    header: CmsHeader!
+    """Image of the editorial."""
+    image: Image!
+    """Image position in the editorial, can be left or right."""
+    imagePosition: String!
+    """Text of the editorial."""
+    text: String!
+    """Background color in HEX."""
+    backgroundColor: String!
+    """Primary link of the editorial."""
+    primaryLink: Link
+    """Secondary link of the editorial."""
+    secondaryLink: Link
+}
+
+"""Emergency message."""
+type EmergencyMessage {
+    """Display title."""
+    title: String!
+    """Message content."""
+    content: String!
+    """Urgency level."""
+    urgency: Urgency!
+}
+
+"""
+Generic interface for the basic property every entry from CMS has. Specific entries implement this interface.
+"""
+interface EntryResponse {
+    """The language the content of this entry is in, coming from CMS."""
+    language: String!
+    """Title of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+}
+
+"""
+Represents an A/B tests within bol For more details check https://docs.bol.io/experimentation-cookbook/index.html
+"""
+type Experiment {
+    """The key of an Experiment (example: BSKT-428 or PATH-1497)"""
+    key: ID!
+    """Variants of an Experiment."""
+    variants: [ExperimentVariant!]!
+}
+
+"""A type of variant of an experiment."""
+type ExperimentVariant {
+    """
+    Key of an Experiment related to this variant (example: 'a' or 'control')
+    """
+    experimentKey: ID!
+    """
+    Allocations of an Experiment. Used for bucketing. The allocation will be a number between 0 and 100 (total allocations). For more info check here: https://docs.bol.io/experimentation-cookbook/in-depth/implementing.html#bucketing
+    """
+    allocations: [Allocation!]!
+    """
+    For test purposes we can override an Experiment variant. For more info check out this document: https://docs.bol.io/experimentation-cookbook/in-depth/verifying.html#forcing_a_variant_visual
+    """
+    overrides: [String]
+}
+
+"""This represents a favorite shelve"""
+type FavoriteShelve {
+    """ID of the favorite shelve"""
+    id: ID!
+}
+
+"""Flagship Menu."""
+type FlagshipLink {
+    """Title of the menu."""
+    title: String!
+    """Subtitle of the menu."""
+    subtitle: String
+    """Url of the menu."""
+    url: String!
+    """Promo parameter."""
+    promoParameter: String!
+    """Text color of the menu."""
+    textColor: String!
+}
+
+"""Banner shown on a campaign page when there are flash deals."""
+type FlashDealsHero {
+    """Image of the hero."""
+    image: Image!
+    """Mobile image of the hero."""
+    mobileImage: Image!
+    """Background color of the hero."""
+    backgroundColor: String!
+    """Title, used for screen readers."""
+    title: String!
+    """Background color of the flash deals."""
+    flashDealsBackgroundColor: String!
+}
+
+"""The type of price that is shown as the `fromPrice`."""
+enum FromPriceType {
+    """
+    Regular prices indicate a price that the product was at in recent time.
+    """
+    REGULAR
+    """List prices indicate the recommended listing price."""
+    LIST
+}
+
+"""The different fulfillment labels"""
+enum FulfillmentLabel {
+    """Select fulfillment"""
+    SELECT
+}
+
+"""Gift card response."""
+type GiftCard {
+    """Gift card code."""
+    code: String!
+    """Gift card remained value."""
+    remainingValue: BigDecimal
+    """Status of the gift card."""
+    status: GiftCardStatus
+    """Gift card expiration date."""
+    expirationDate: LocalDateTime
+    """Error code if there is any error for the gift card."""
+    errorCode: String
+}
+
+"""Status of a gift card."""
+enum GiftCardStatus {
+    ACTIVE
+    INACTIVE
+    REDEEMED
+    BLOCKED
+    SUBSTITUTED
+    EXPIRED
+    DISABLED
+}
+
+"""Global Product Classification, also known as 'GPC'"""
+type GlobalProductClassification {
+    """Identifier for the brick"""
+    brick: ID
+    """Identifier for the chunk"""
+    chunk: ID
+}
+
+"""
+Entry of content type HERO_BANNER. A HERO_BANNER is a banner displayed on a campaign page.
+"""
+type HeroBanner {
+    """Image of the hero banner."""
+    image: Image!
+    """Mobile image of the hero banner."""
+    mobileImage: Image!
+    """Background color of the banner in HEX."""
+    backgroundColor: String!
+    """Display title of the hero banner."""
+    title: String!
+    """Optional subtitle of the hero banner."""
+    subtitle: String
+}
+
+type IdentifiedCustomer implements Customer {
+    notUsed: Boolean! @deprecated(reason: "Do not use this field")
+    recentlyViewed: ProductConnection
+    favoriteShelves: ProductCategoryConnection
+    productCategories: ProductCategoryConnection
+    firstName: String!
+    infix: String
+    lastName: String!
+    """
+    The select subscription of a customer, null if the customer has no select
+    """
+    selectSubscription: SelectSubscription
+    """Deals grouped by brand"""
+    brandDeals: [BrandDeals!]
+    """
+    Returns Top Deals (Promotional feed) with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    promotionalFeed: ProductConnection
+    """
+    Returns New for You with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    newForYou: ProductConnection
+    """
+    Returns Top Picks with list of personalized products per unique customer (if logged in/ recognised and consent given, else fallback popular products)
+    """
+    topPicks: ProductConnection
+    """
+    Returns Brands with list of personalized brand items per unique customer (if logged in/ recognised and consent given, else fallback popular brand items)
+    """
+    favoriteBrands: BrandConnection @deprecated(reason: "Use brandsDeals query instead")
+}
+
+"""Attributes of an Image."""
+type Image {
+    """Image url."""
+    url: String!
+    """Image title."""
+    title: String!
+}
+
+"""A representation of the color of an image, in HSL format"""
+type ImageColor {
+    """Hue value from 0 to 360"""
+    hue: Int!
+    """Saturation value from 0 to 100%"""
+    saturation: Int!
+    """Lightness value from 0 to 100%."""
+    lightness: Int!
+}
+
+type InvalidUserProblem {
+    description: String!
+}
+
+type InvalidWishlistNameLengthProblem {
+    description: String!
+}
+
+""" The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+"""
+Entry of content type LEGAL_ARTICLE. A LEGAL_PAGE can contain multiple of these entries.
+"""
+type LegalArticleResponse implements EntryResponse {
+    """The locale the content of this entry is in, coming from CMS."""
+    language: String!
+    """Name of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+    """Display title of the entry, mandatory for all entries."""
+    displayTitle: String
+    """HTML content of the legal article."""
+    contentHtml: String!
+}
+
+"""A section grouping common legal terms."""
+type LegalLegalTermSectionResponse {
+    """Title of the legal terms."""
+    name: String!
+    """All the legal pages in this term section."""
+    legalPages: [LegalPageResponse]!
+}
+
+"""
+Entry of content type LEGAL_OVERVIEW_PAGE, contains all the legal terms of bol.com.
+"""
+type LegalOverviewPageResponse implements EntryResponse {
+    """The locale the content of this entry is in, coming from CMS."""
+    language: String!
+    """Name of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+    """Display title of the entry, mandatory for all entries."""
+    displayTitle: String
+    """URL of legal overview page."""
+    url: String
+    """Legal terms sections contained in the overview."""
+    termsSections: [LegalLegalTermSectionResponse]!
+    """SEO metadata for the legal overview page."""
+    seoMetadata: CmsSeoMetadata!
+}
+
+"""Entry of content type LEGAL_PAGE."""
+type LegalPageResponse implements EntryResponse {
+    """The locale the content of this entry is in, coming from CMS."""
+    language: String!
+    """Name of the entry, mandatory for all entries, coming from CMS."""
+    name: String!
+    """Display title of the legal page."""
+    displayTitle: String
+    """URL of legal page."""
+    url: String
+    """Intro section of legal page, contains multiple lines of text."""
+    intro: String
+    """The legal article entries, which are part of this page."""
+    articles: [LegalArticleResponse]
+    """SEO metadata for this legal page."""
+    seoMetadata: CmsSeoMetadata!
+}
+
+"""A link."""
+type Link {
+    """Link title."""
+    title: String
+    """Link URL."""
+    url: String
+}
+
+""" Representation of a ISO-8601 DateTime instance without offset or zone information.
+"""
+scalar LocalDateTime
+
+"""The loyalty program"""
+type LoyaltyProgram {
+    id: ID!
+    """The number of loyalty points a customer has"""
+    points: Int!
+}
+
+"""Input for a container measurement"""
+input M2ContainerInput {
+    """ID of the container that is measured"""
+    id: ID!
+    """Request properties for the measurement"""
+    context: M2MeasurementContext
+    """Details regarding the container measurement"""
+    details: M2MeasurementContainerDetails
+    """HookId of the hook that led to this container render measurement"""
+    cause: ID
+}
+
+input M2EventAdElementInput {
+    """Id of the item"""
+    id: ID!
+    """position of the item"""
+    position: Int
+    """Promotion code associated with the ad"""
+    promoCode: String
+    """Targeting ID of the ad"""
+    targetingId: ID
+    """Content ID of the ad"""
+    contentId: ID
+    """Moment in time that the measurement was captured"""
+    timestamp: Moment
+    """Slot ID"""
+    slotId: String
+}
+
+"""Input for a view measurement"""
+input M2EventAdInput {
+    """Moment in time that the measurement was sent"""
+    timestamp: Moment
+    """List of view elements to be measured"""
+    measurements: [M2EventAdElementInput!]!
+}
+
+"""Input for a group measurement"""
+input M2GroupInput {
+    """ID of the container that is measured"""
+    id: ID!
+    """Position of the group within the container"""
+    position: Int
+    """Details for the group measurement"""
+    details: M2MeasurementGroupDetails
+    """Enabled experiment variants for this group."""
+    experiments: [String!]
+}
+
+"""Input for an item measurement"""
+input M2ItemInput {
+    """ID of the container that is measured"""
+    id: ID!
+    """Position of the item within the container"""
+    position: Int
+    """Details for the item measurement"""
+    details: M2MeasurementItemDetails
+}
+
+"""Details regarding the container measurement"""
+input M2MeasurementContainerDetails {
+    """Page details for a container measurement"""
+    page: M2MeasurementContainerDetailsPage
+}
+
+"""Page details for a container measurement"""
+input M2MeasurementContainerDetailsPage {
+    """
+    " ID of the page, typically this is the main resources of the page. Examples are CampaignID for a campaign page. Brand ID for a BAP or Product ID for the PDP. Only required when relevant.
+    """
+    id: ID @deprecated(reason: "Replaced by `ids`")
+    """
+    Page level IDs that need to be measured. Examples are CampaignID for a campaign page. Brand ID for a BAP or Product ID for the PDP. Only required when relevant.
+    """
+    ids: [M2PageIdPairInput!]
+    """The name of the page"""
+    name: M2MeasurementPageName
+}
+
+"""
+Contextual information associated with a measurement, often includes information that can only be collected from the client
+"""
+input M2MeasurementContext {
+    """Request related properties of the interaction"""
+    request: M2MeasurementContextRequest
+    """App information of the service that sent the interaction"""
+    app: M2MeasurementContextApp
+}
+
+"""
+App information related to the service that sent the interaction. In practicality this will be the information from the Web Micro Frontend or App Template Engine
+"""
+input M2MeasurementContextApp {
+    """application name"""
+    name: String!
+    """Current running version of the application that sent the measurement"""
+    version: String!
+}
+
+"""Request related properties of the interaction"""
+input M2MeasurementContextRequest {
+    """
+    URL of the resource that was loaded. This includes the FQDN. An example is `https://www.bol.com/nl/nl/foobar?bar=baz`
+    """
+    url: String
+    """Referrer value as determined by the client"""
+    referrer: String
+}
+
+input M2MeasurementGroupDetails {
+    """
+    Type of the group measurement, should be consistent across similar group types
+    """
+    type: String
+    """
+    The title of the slot as shown to the customer. Examples are 'Recently visited product', 'Top picks for you' or 'Anderen bekeken ook'
+    """
+    title: String
+}
+
+input M2MeasurementItemDetails {
+    """The set of resource IDs that are referenced in the item"""
+    resources: [ID!]!
+    """The hookIds that are part of the item"""
+    hooks: [ID!]
+}
+
+"""Pages that can be measured as a container"""
+enum M2MeasurementPageName {
+    """Seller page"""
+    SELLER_PAGE
+    """Campaign pages"""
+    CAMPAIGN
+    """Store Front pages"""
+    STORE_FRONT
+    """Legal pages"""
+    LEGAL
+    """Home page"""
+    HOME
+    """Brands pages"""
+    BRAND
+    """Brand Campaign pages"""
+    BRAND_CAMPAIGN
+    """Information pages (/inf)"""
+    INFORMATION
+}
+
+input M2PageIdPairInput {
+    """Type of the identifier that needs to be measured"""
+    type: M2PageIdType!
+    """Value of the identifier"""
+    value: ID!
+}
+
+"""Type of page id that needs to be measured"""
+enum M2PageIdType {
+    """Identifies an advertiser"""
+    ADVERTISER_ID
+    """Identifies a campaign of a specific advertiser"""
+    ADVERTISING_CAMPAIGN_ID
+    """Identifies a party, like a brand"""
+    PARTY_ID
+    """Identifies a campaign of a specific brand"""
+    BRAND_CAMPAIGN_ID
+    """Identifies a first party campaign"""
+    CAMPAIGN_ID
+    """Identifies a retailer"""
+    RETAILER_ID
+    """Identifies a product"""
+    PRODUCT_ID
+}
+
+"""An element that has been in view"""
+input M2ViewElementInput {
+    """Moment in time that the view measurement was generated"""
+    timestamp: Moment
+    """
+    ID of the element that came into view, can be a container, group or item.
+    """
+    id: ID!
+}
+
+"""Input for a view measurement"""
+input M2ViewInput {
+    """Information about the viewport"""
+    viewport: M2ViewPortInput
+    """Moment in time that the measurement was sent"""
+    timestamp: Moment
+    """List of view elements to be measured"""
+    measurements: [M2ViewElementInput!]!
+}
+
+"""
+Information about the viewport of the device, if the device has a visual presentation element
+"""
+input M2ViewPortInput {
+    """Width of the viewport, in pixels"""
+    width: Int
+    """Height of the viewport, in pixels"""
+    height: Int
+}
+
+"""Marketing Menu."""
+type MarketingMenu {
+    """List of menus."""
+    items: [MarketingMenuItem!]!
+    """Flagship menu, will be shown on the right side of the marketing menu."""
+    flagshipLink: FlagshipLink!
+}
+
+"""Marketing Menu Item."""
+type MarketingMenuItem {
+    """Title of the menu."""
+    title: String!
+    """Url of the menu."""
+    url: String!
+    """Promo parameter."""
+    promoParameter: String!
+}
+
+type MaxItemsPerWishListLimitReachedProblem {
+    description: String!
+}
+
+"""Representation of a menu items"""
+type MenuItem {
+    """ID of the menu item"""
+    id: ID!
+    """
+    The title of the menu item which is dictated by the language and country you specify in the menuItems query
+    """
+    title: String!
+    """The image url that belong to this menu item 160x160 size"""
+    imageUrl: String
+    """The image header url that belong to this menu item 460x350 size"""
+    imageHeaderUrl: String
+    """The level in which the menu item belongs"""
+    level: Int!
+    """The potential children that might be attached to this menu items"""
+    children: [MenuItem!]
+    """
+    The action field holds the presentation logic that a consumer should follow
+    """
+    action: MenuItemAction!
+    """The measurement field attached to this menu item"""
+    measurement: MenuItemMeasurement
+    """The logically grouping of parent menu items only used in doormat"""
+    group: Int!
+}
+
+"""Representation of a menu items action"""
+type MenuItemAction {
+    """The action type of a menu item"""
+    menuItemActionType: MenuItemActionType!
+    """
+    The url that might be present, a menu item can have a url if it is of type 'URL'
+    """
+    url: String
+}
+
+"""
+Representation of a menu items action types, the action type dictates what the consumer should do with this menu items
+"""
+enum MenuItemActionType {
+    """A 'URL' type contains a url that should be followed"""
+    URL
+    """
+    A 'CHILD' type indicates that this menu item has children and it is not a leaf node
+    """
+    CHILD
+    """
+    A 'PARENT' menu item should be displayed with an image on the current frontend and should not be clickable
+    """
+    PARENT
+}
+
+"""Representation of a menu item measurement"""
+type MenuItemMeasurement {
+    """
+    This is used by analytics and looks like 'mainnav:Books:Cars & Motor:Books' it a string of all the english titles form the parent menu items all the way down to the leaf menu items
+    """
+    clickedMenuItem: String!
+}
+
+"""A button."""
+type MoatButton {
+    """Display title."""
+    title: String!
+    """Url."""
+    url: String!
+    """Appearance: primary or secondary."""
+    appearance: String!
+}
+
+"""A day deal for a campaign page."""
+type MoatDayDeal implements MoatDeal {
+    """Title of the deal."""
+    title: String!
+    """Subtitle of the deal."""
+    subtitle: String!
+    """Promo parameter."""
+    promoParameter: String!
+    """Deal date."""
+    dealDate: String!
+    """Url of the deal"""
+    url: String
+    """Deal type."""
+    dealType: String!
+    """Disclaimer of the deal."""
+    disclaimer: String
+    """The PCS product in the deal."""
+    product: Product!
+    """Response type."""
+    type: DealResponseType!
+}
+
+"""A promotional deal (coming from Promo Suite)."""
+interface MoatDeal {
+    """Title of the deal."""
+    title: String!
+    """Subtitle of the deal."""
+    subtitle: String!
+    """Promo parameter."""
+    promoParameter: String!
+    """Deal date."""
+    dealDate: String!
+    """Url of the deal."""
+    url: String
+    """Deal type."""
+    dealType: String!
+    """Disclaimer of the deal."""
+    disclaimer: String
+    """The PCS product in the deal."""
+    product: Product!
+    """Response type."""
+    type: DealResponseType!
+}
+
+"""A Moat flash deal."""
+type MoatFlashDeal implements MoatDeal {
+    """Title of the deal."""
+    title: String!
+    """Subtitle of the deal."""
+    subtitle: String!
+    """Promo parameter."""
+    promoParameter: String!
+    """Deal date."""
+    dealDate: String!
+    """End time of the deal"""
+    endTime: String
+    """Flash deal's start date"""
+    startDateTime: String!
+    """Flash deal's end date"""
+    endDateTime: String!
+    """Url of the deal"""
+    url: String
+    """Deal type."""
+    dealType: String!
+    """Disclaimer of the deal."""
+    disclaimer: String
+    """The PCS product in the deal."""
+    product: Product!
+    """Response type."""
+    type: DealResponseType!
+}
+
+"""A CMS component which displays information with text and media."""
+type MoatInformationCard {
+    """Title."""
+    title: String!
+    """Paragraph of text."""
+    paragraph: String!
+    """Link."""
+    link: Link
+    """Image."""
+    image: Image
+}
+
+"""A section of information cards."""
+type MoatInformationCards {
+    """Title."""
+    title: String
+    """Subtitle."""
+    subtitle: String
+    """How to display the cards, example: list or carousel."""
+    displayMode: String!
+    """Image ratio: 16:9, 1:1 or 4:3."""
+    imageRatio: String!
+    """Background color in HEX."""
+    backgroundColor: String!
+    """The information cards"""
+    informationCards: [MoatInformationCard!]!
+}
+
+"""A jumpstation card."""
+type MoatJumpstationCard {
+    """Title of the jumpstation card."""
+    title: String!
+    """Image of the jumpstation card."""
+    image: Image!
+    """Link to category which this card should link to."""
+    categoryLink: String
+    """Collection of links for the jumpstation card."""
+    links: [Link]!
+    """Text to show under 'All items'."""
+    allItemsText: String
+}
+
+"""
+A CMS component which contains an optional title and a list of jumpstation cards.
+"""
+type MoatJumpstationCards {
+    """Title of the jumpstation cards section."""
+    title: String
+    """Color for the background of the section of jumpstation cards."""
+    backgroundColor: String!
+    """The jumpstation cards"""
+    jumpstationCards: [MoatJumpstationCard!]!
+}
+
+"""A card for one party (a.k.a brand)."""
+type MoatPartyCard {
+    """Title."""
+    title: String
+    """Subtitle."""
+    subtitle: String
+    """Title for accessibility/screen readers."""
+    accessibilityTitle: String!
+    """Image of the party cards."""
+    image: Image!
+    """Indicates whether the image should have a border or not."""
+    hasImageBorder: Boolean!
+    """URL to redirect to from the card."""
+    url: String!
+}
+
+"""A CMS component which displays parties (a.k.a brands)."""
+type MoatPartyCards {
+    """Title."""
+    title: String
+    """Subtitle."""
+    subtitle: String
+    """How to display the cards, example: list or carousel."""
+    displayMode: String!
+    """
+    Indicates whether one or more of the cards have been sponsored by the brands it represents.
+    """
+    sponsored: Boolean!
+    """The party cards."""
+    partyCards: [MoatPartyCard!]!
+}
+
+"""A product carousel."""
+type MoatProductCarousel {
+    """Title of the carousel."""
+    title: String
+    """Subtitle of the carousel."""
+    subtitle: String
+    """Products in the carousel."""
+    products: [Product!]!
+}
+
+"""
+A CMS component which displays a text with a title and subtitle on a page.
+"""
+type MoatTextSnippet {
+    """Header."""
+    header: CmsHeader!
+    """Text of the text snippet."""
+    text: String!
+}
+
+"""A theme card."""
+type MoatThemeCard {
+    """Header."""
+    header: CmsHeader!
+    """URL of the card."""
+    url: String!
+    """Image of the card."""
+    image: Image!
+    """Background color in HEX."""
+    backgroundColor: String!
+}
+
+"""A CMS component which contains a list of theme cards."""
+type MoatThemeCards {
+    """Optional title of Theme card section."""
+    title: String
+    """Optional subtitle."""
+    subtitle: String
+    """
+    Specifies if the image and title are in the same box with same background or not.
+    """
+    contained: Boolean!
+    """Image ratio: 16:9 or 1:1."""
+    imageRatio: String!
+    """Background color in HEX."""
+    backgroundColor: String!
+    """How to display the cards, example: list or carousel."""
+    displayMode: String!
+    """The theme cards"""
+    themeCards: [MoatThemeCard!]!
+}
+
+"""Attributes of Video."""
+type MoatVideo {
+    """Title of the video."""
+    videoTitle: String!
+    """Subtitle of the video."""
+    subtitle: String
+    """Background color of the video."""
+    videoBackgroundColor: Color
+    """thumbnail of the video."""
+    video: VideoFile!
+    """thumbnail of the video."""
+    thumbnail: Image!
+    """AutoPlay Boolean."""
+    autoPlay: Boolean!
+    """Url of the video."""
+    url: Link
+    """Text"""
+    text: String
+}
+
+"""A specific point in time on the timeline, expressed in UTC."""
+scalar Moment
+
+"""Used to describe monetary amounts."""
+type Money {
+    """The amount of money, in arbitrary precision."""
+    amount: BigDecimal!
+    """The currency code for the currency."""
+    currencyCode: String!
+}
+
+input MoveItemToExistingWishlistInput {
+    """ID of the product to move to the wishlist"""
+    productId: ID!
+    """The ID of the wishlist from which the item can be removed"""
+    fromWishlistId: ID!
+    """The ID of the wishlist to which the item needs to be moved"""
+    targetWishlistId: ID!
+    """Determines how the wishlist in the response are sorted"""
+    sortedBy: WishlistSortOption! = MUTATION_DESC
+}
+
+union MoveItemToExistingWishlistResult = WishlistOverview | InvalidUserProblem | NoWishlistFoundForCustomerProblem | MaxItemsPerWishListLimitReachedProblem
+
+input MoveItemToNewWishlistInput {
+    """ID of the product to add to the wishlist"""
+    productId: ID!
+    """Name of the new wishlist"""
+    wishlistName: String!
+    """The ID of the wishlist from which the item can be removed"""
+    fromWishlistId: ID!
+    """Determines how the wishlist in the response are sorted"""
+    sortedBy: WishlistSortOption! = MUTATION_DESC
+}
+
+union MoveItemToNewWishlistResult = WishlistOverview | InvalidUserProblem | NoWishlistFoundForCustomerProblem | InvalidWishlistNameLengthProblem
+
+"""
+Root Mutation type for performing various actions on baskets or basket messages.
+"""
+type Mutation {
+    """Basket mutations for creating, updating, and manipulating baskets."""
+    basket: BasketMutations
+    """Basket mutations deleting messages."""
+    basketMessages: BasketMessageMutations
+    wishlist: WishlistMutations
+    """Measure a container in m2. Always returns true."""
+    measureContainer(input: M2ContainerInput!): Boolean!
+    """Measure a group. Always returns true."""
+    measureGroup(input: M2GroupInput!): Boolean!
+    """
+    Measure multiple groups. Accepts a maximum of 100 elements. If more than 100 elements are provided the entire call will be rejected. Always returns true.
+    """
+    measureGroups(input: [M2GroupInput!]!): Boolean!
+    """Measure a item. Always returns true."""
+    measureItem(input: M2ItemInput!): Boolean!
+    """
+    Measure multiple items. Accepts a maximum of 100 elements. If more than 100 elements are provided the entire call will be rejected. Always returns true.
+    """
+    measureItems(input: [M2ItemInput!]!): Boolean!
+    """Measure a view. Always returns true."""
+    measureView(input: M2ViewInput!): Boolean!
+    """Measure an Ad. Always returns true"""
+    measureAd(input: M2EventAdInput): Boolean!
+    """Namespace for consent mutations"""
+    consent: ConsentMutations
+}
+
+type NoWishlistFoundForCustomerProblem {
+    description: String!
+}
+
+"""Type representing an offer."""
+type Offer {
+    """External identifier for the offer."""
+    id: ID! @deprecated(reason: "This field usage should be replaced with the `uid` field.")
+    """A unique id of this offer across all of bol.com."""
+    uid: ID!
+    bestDeliveryOption: BestDeliveryOption
+    """Used for generating Offer M2 measurements"""
+    hash: String
+    """
+    An id for the offer tied to the specific retailer. It can identify an offer in combination with a productId.
+    """
+    retailerOfferId: ID! @deprecated(reason: "This field usage should be replaced with the `id` field (`sellingOfferId`), or `offerUid` in the future.")
+    """The language of the content returned."""
+    language: String! @deprecated(reason: "in favor of customer context headers")
+    """The id of the product offered."""
+    productId: ID! @deprecated(reason: "The productId field is superseded by the `product` attribute which offers richer information")
+    """The product this offer is applicable for."""
+    product: Product
+    """The price of the offer"""
+    price: Money!
+    """Strikethrough prices of the offer."""
+    strikethroughPrices: [StrikethroughPrice!]! @deprecated(reason: "Use the `fromPrice` and `fromPriceType` instead.")
+    """
+    If the price is a discount price, the fromPrice will contain either the previously shown price or the listing price.
+    """
+    fromPrice: Money
+    """Returns the type of price that is shown as the `fromPrice`."""
+    fromPriceType: FromPriceType
+    """
+    Select deal if available, regardless of whether the customer is a select-customer or not. To determine when to show the select deal if present, clients will need to implement their own logic for now.
+    """
+    selectDeal: SelectDeal
+    """Whether the offer's product is in stock or not"""
+    inStock: Boolean! @deprecated(reason: "An offer will always be 'in stock' if it is returned, so this will always be true. Digital products and crossdock offers could have no quantity but then it can be still be sold.")
+    """
+    A suitable-for-humans description of how long it takes to deliver the product. This attribute is language-dependent
+    """
+    deliveryDuration: String
+    """
+    Describes what fulfillment option the offer provides or null if not defined
+    """
+    fulfillmentLabel: FulfillmentLabel
+    """
+    The delivery charges for this product. Currently mocked. returns 'gratis verzending'
+    """
+    deliveryCharges: String!
+    """Discount label"""
+    discountLabel: PromoLabel
+}
+
+"""Page info, as specified by https://relay.dev/graphql/connections.htm."""
+type PageInfo {
+    """Indicator for whether there is a next page available"""
+    hasNextPage: Boolean!
+    """Indicator for whether there is a previous page available"""
+    hasPreviousPage: Boolean!
+    """The last cursor on this page"""
+    endCursor: String
+    """The first cursor on this page"""
+    startCursor: String
+}
+
+"""Type representing a product."""
+type Product {
+    """Id of Product"""
+    id: ID!
+    """The primary image for this product."""
+    image: ProductImage @deprecated(reason: "(2023-12-01) use 'assets(mediaType: [IMAGE], limit: 1)' instead")
+    """The images for this product."""
+    images: [ProductImage!] @deprecated(reason: "(2023-12-01) use 'assets(mediaType: [IMAGE])' instead")
+    """
+    The list of assets in the publication. The mediaType field filters assets based on specific media types. If not explicitly mentioned, it shows all assets. The limit parameter can be used to restrict the number of returned assets.
+    """
+    assets(mediaType: [AssetMediaType!], limit: Int): [Asset!]
+    """List of wishlists this product is a part of"""
+    wishlists: [Wishlist!]
+    """Used for generating Product M2 measurements"""
+    hash: String
+    """The title of the product"""
+    title: String
+    """
+    promo parameter of Product. This is used when we have only product id and we want to build promo parameter with extra data that we have internally, current use case is: fetching product via product carousel in campaign page.
+    """
+    promoParameter: String
+    """
+    Language in which the product content is written (deprecated, will no longer be filled)
+    """
+    language: String @deprecated(reason: "Will no longer be filled")
+    """SEO-friendly slug for better search engine ranking"""
+    slug: String
+    """Attributes associated with the product"""
+    attributes: [ProductAttribute!]
+    """Family to which the product belongs"""
+    family: ProductFamily
+    """Parties associated with the product"""
+    parties: [ProductParty!]
+    """Global product classification information with brickId and chunkId"""
+    globalProductClassification: GlobalProductClassification
+    """
+    The best offer for this product This attribute might return `null` if there is no offer for the given region (so the product is unavailable).
+    """
+    bestOffer: Offer
+    """Relative url to the product page of this product"""
+    url: String
+}
+
+"""A product attribute"""
+type ProductAttribute {
+    """Name of the attribute"""
+    name: String!
+    """Values associated with the attribute"""
+    values: [ProductAttributeValue!]
+}
+
+"""A value associated with a product attribute"""
+type ProductAttributeValue {
+    """Identifier for the attribute value (only present for some attributes)"""
+    valueId: String
+    """The value of the attribute (not present on all ProductAttributeValues)"""
+    value: String
+}
+
+"""This represents a product category"""
+type ProductCategory {
+    """ID of the product category"""
+    id: ID!
+    """The name of this Category."""
+    name: String!
+    """The order of this Category."""
+    order: Int!
+    """The parent ID of this Category."""
+    parent: ProductCategory
+}
+
+type ProductCategoryConnection {
+    """A collection of edges that match the connection specification"""
+    edges: [ProductCategoryEdge]
+    """Metadata about the connection"""
+    pageInfo: PageInfo
+}
+
+"""
+The "edge" for a collection of product categories. See https://relay.dev/graphql/connections.htm.
+"""
+type ProductCategoryEdge {
+    """
+    The cursor for the edge, in this case based in the index of the element
+    """
+    cursor: String
+    """The actual data tied to the cursor, in this case the product category"""
+    node: ProductCategory
+}
+
+"""
+A collection of products, structured as a "connection", defined by https://relay.dev/graphql/connections.htm .
+"""
+type ProductConnection {
+    """A collection of edges that match the connection specification"""
+    edges: [ProductEdge]
+    """Metadata about the connection"""
+    pageInfo: PageInfo
+}
+
+type ProductDeal implements Deal {
+    """The title of the `Deal`."""
+    title: String!
+    """The title of the `Deal` with Markup language."""
+    markupTitle: String!
+    """The subtitle of the `Deal`."""
+    subtitle: String!
+    """
+    Product reference, intended for showing product information only. For the offer information, use the `offer` field of this `ProductDeal`.
+    """
+    highlightedProduct: Product
+    """The DateTime when the `Deal` ends."""
+    expiresAt: DateTime!
+    """The promoParameter for the link of the `Deal`."""
+    promoParameter: String!
+    """ACM Disclaimer for the `Deal`."""
+    disclaimer: String
+    """The type of the `Deal`"""
+    type: DealType!
+    """The offer information for the `highlightedProduct` of this `Deal`."""
+    offer: Offer
+}
+
+"""
+The "edge" for a collection of products. See https://relay.dev/graphql/connections.htm.
+"""
+type ProductEdge {
+    """
+    The cursor for the edge, in this case based in the index of the element
+    """
+    cursor: String
+    """The actual data tied to the cursor, in this case the product"""
+    node: Product
+}
+
+"""Representation of a product family"""
+type ProductFamily {
+    """Unique identifier for the family"""
+    id: ID!
+    """Distinctive features of the family"""
+    distinctiveFeatures: [String!]
+}
+
+"""A product image"""
+type ProductImage {
+    """The usage type of the product image"""
+    usage: String!
+    """The different rendition options for this image"""
+    renditions: ProductImageRenditions!
+    """
+    Primary color information for the image returned. If there is no image for the requested image size the primary color will be based off of the default image.
+    """
+    primaryColor: ImageColor!
+    """The aspect ratio of all the image renditions"""
+    aspectRatio: Int!
+}
+
+"""Size of a specific image"""
+type ProductImageRendition {
+    """The image location."""
+    url: String!
+    """The width of the image rendition, in pixels"""
+    width: Int!
+    """The height of the image rendition, in pixels"""
+    height: Int!
+}
+
+"""
+The different rendition options for an image. Each rendition has a maximum frame size and the image is guaranteed to fit within that frame. A rendition maintains it's original aspect size within the frame. A rendition is nullable, null is returned when no rendition for the requested size can be found.
+"""
+type ProductImageRenditions {
+    """A rendition with a frame size of 1200w x 1200h pixels."""
+    xl: ProductImageRendition
+    """A rendition with a frame size of 550w x 840h pixels."""
+    l: ProductImageRendition
+    """A rendition with a frame size of 168w x 210h pixels."""
+    m: ProductImageRendition
+    """A rendition with a frame size of 124w x 155h pixels."""
+    s: ProductImageRendition
+    """A rendition with a frame size of 100w x 125h pixels."""
+    xs: ProductImageRendition
+    """A rendition with a frame size of 48w x 60h pixels."""
+    xxs: ProductImageRendition
+}
+
+"""Representation of a product party"""
+type ProductParty {
+    """Unique identifier for the party"""
+    id: ID!
+    """Name of the party"""
+    name: String!
+    """Rank of the party"""
+    rank: Int!
+    """Role of the party"""
+    role: String!
+    """
+    Type of the party (example values: ["BRAND", "AUTHOR", "PUBLISHER", "ACTOR"]) For more values see: https://gitlab.bol.io/team-1c/phoenix/phoenix-app/-/blob/master/phoenix-app/src/main/kotlin/com/bol/phoenix/app/dao/model/RelationType.kt#L5
+    """
+    type: String!
+}
+
+"""Type of Product Recommendation Campaign."""
+enum ProductRecommendationsCampaign {
+    """Vaak samen gekocht / Often bought together campaign for the basket"""
+    VSG_BASKET
+}
+
+type PromoLabel {
+    """The title of this promo label."""
+    title: String!
+}
+
+"""A Promotion Card for a campaign page."""
+type PromotionCard {
+    """campaign Id."""
+    campaignId: String!
+    """Action id."""
+    actionId: Int!
+    """Promotion title."""
+    title: String!
+    """Promotion subtitle."""
+    subtitle: String
+    """Title color."""
+    titleColor: String!
+    """Background color."""
+    backgroundColor: String!
+    """Subtitle color."""
+    subtitleColor: String
+    """Image url of a card."""
+    imageUrl: String!
+    """Card Link."""
+    link: PromotionLinkResponse!
+    """Acm Disclaimer."""
+    acmDisclaimer: String
+    """Card Button Color."""
+    cardButtonColor: String!
+}
+
+"""Link of the promotion card."""
+type PromotionLinkResponse {
+    """Custom link."""
+    customLink: CustomLink
+    """Retail action link."""
+    retailActionLink: RetailActionLink
+}
+
+"""Root Query type for fetching and querying baskets."""
+type Query {
+    """
+    AdTransparency information that is associated with an ad from `advertiserId` provided by `adProvider`. The `payerAdvertiserId` can optionally be supplied if known. `adProvider` can be any of the following, in uppercase: MABAYA, SP3, LDE, PEGA
+    """
+    adTransparency(adProvider: String!, advertiserId: ID!, payerAdvertiserId: ID): AdTransparency
+    """Retrieve a specific basket by its ID."""
+    basket(id: ID!): Basket
+    """Retrieve a list of all baskets."""
+    baskets: [Basket]!
+    """Retrieve a list of all Messages based on the resource type."""
+    basketMessages(resourceId: ID!, resourceType: BasketMessageResourceTypeInput!): [BasketMessage]!
+    cms: cmsQuery
+    """Fetch a list of menu items by id,levels,country,language and type"""
+    menuItems(id: String = "0", levels: String = "0", country: String = "NL", language: String = "nl-NL", type: String = "MAIN_NAVIGATION"): [MenuItem!]
+    assetPublication(referenceType: String!, referenceId: ID!): AssetPublication
+    """Ad-context to generate targeted google ads"""
+    adContext(adContextInput: AdContextInput!): [AdContext]
+    """
+    Returns a legal page entry with a specified `url` and `language` and 'country'. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    legalPage(url: String!, language: String, country: Country): LegalPageResponse @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns a legal overview page entry with a specified `url` and `language` and 'country'. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    legalOverviewPage(url: String!, language: String, country: Country): LegalOverviewPageResponse @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns a campaign page response for the specified `campaignId` in the specified `language` for the specified `country`. If `shelfIds` are provided, the promotional banners are filtered based on the provided list. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    campaignPage(campaignId: Int!, language: String, country: Country, shelfIds: [String!] @ContainerSize(max: 150)): CampaignPageResponse @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns an emergency message for the specified `language` and `country`. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    emergencyMessage(language: String, country: Country): EmergencyMessage @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns a banner carrousel for the specified `carrouselNames` in the specified `language` for the specified `country`. NOTE: In the current setup there are always two banners - top and bottom. It might change in the future. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    bannerCarrouselApp(carrouselNames: [String], language: String, country: Country): [BannerCarrouselApp] @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns a storefront page with the specified `name` in the specified `language` and `country`. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    storefrontPage(name: String!, language: String, country: Country): StorefrontPage @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns marketing menu in the specified `language` and `country`. NOTE: `language` and `country` are deprecated. Values are read from 'Accept-Language' & 'Bol-Shop-Country' header.
+    """
+    marketingMenu(language: String, country: Country): MarketingMenu @deprecated(reason: "Use cms (moat csproxy) instead")
+    """
+    Returns data usage and data sharing consent associated with device and/or customer
+    """
+    consent: Consent
+    """Fetch a product by its ID"""
+    product(id: ID!, language: String @deprecated(reason: "Use customer context headers instead")): Product
+    """
+    Returns a text resource with a particular name, for a particular language. If a resource with the provided language tag is not found, a fallback will be fetched by language only, if available. Example: Request is for resource X in nl-BE. X does not exist in nl-BE, but it does exist in nl, the nl version will be returned.
+    """
+    textResource(language: String @deprecated(reason: "Value is read from 'Accept-Language' in header"), name: String!): TextResource
+    """
+    Returns an Offer by `id`. The `language` parameter is used for all description-like texts, like a description of the product state or the estimated delivery
+    """
+    offer(
+        """
+        The unique identifier of the offer either a sellingOfferId or offerUid can be provided as id. both the SellingOfferId and the offerUid can be passed here as id key and that based on the format is decided which of the two it is.
+        """
+        id: ID!
+        """The language in which the object is returned"""
+        language: String @deprecated(reason: "(29-11-2023) This field is no longer used, the implementation depends on the Accept-Language header instead ")
+    ): Offer
+    activeExperiments: [Experiment]
+    """Returns product recommendations for the given productIds."""
+    productRecommendations(
+        """The productIds for which recommendations are fetched."""
+        productIds: [ID!]!
+        """The campaign for which recommendations are fetched."""
+        campaigns: [ProductRecommendationsCampaign!]!
+        """The max amount of recommendations to return"""
+        limit: Int = 20
+    ): [Product]
+    """
+    Returns a Banners object, which contains a hero banner and flex banners. **IMPORTANT:** You should always request all banners for a page at once, because they are linked to a page interaction based on this request.
+    """
+    banners(
+        """The page type to request the banners for."""
+        pageType: BannerPageType!
+        """The device type to request banners for."""
+        deviceType: DeviceType!
+    ): Banners
+    """Returns a list of all shop the look categories."""
+    shopTheLookCategories: [ShopTheLookCategory!]
+    """Gift Card, returns gift card details."""
+    giftCard(
+        """Gift card number."""
+        cardNumber: String!
+        """Gift card pin code."""
+        pinCode: String
+    ): GiftCard
+    """Retailer for the given id (also called retailer-id)"""
+    retailer(id: ID!): Retailer
+    """The DayDeal for a specific page."""
+    dayDeal(
+        """The page to request a DayDeal for."""
+        page: DayDealPage!
+    ): Deal
+    """Information related to the customer interacting with the graph"""
+    me: Customer
+    """Getting the SEO metadata for different page types"""
+    seoMetadata: SeoMetadataPages
+    """Get Urls by language and region"""
+    urls(language: String @deprecated(reason: "in favor of customer context headers"), region: String @deprecated(reason: "in favor of customer context headers")): Urls
+}
+
+"""Retail action of the promotion card."""
+type RetailActionLink {
+    """Action id."""
+    actionId: Int!
+    """Text of the link."""
+    text: String
+}
+
+"""Type representing a retailer."""
+type Retailer {
+    """External identifier for the retailer."""
+    id: ID!
+    """Name of the retailer"""
+    name: String!
+    """The main retailer page url"""
+    url: String
+}
+
+"""
+Select deal for an offer regardless of customer opted in for select or not.
+"""
+type SelectDeal {
+    """The price for select deal."""
+    price: Money!
+    """The type of select deal."""
+    type: SelectDealType!
+    """The calculated discount saved by applying the select deal."""
+    discount: Discount!
+}
+
+"""The type of select deal."""
+enum SelectDealType {
+    """Select deal is only temporarily available."""
+    TEMPORARY
+    """Select deal will be permanently available."""
+    PERMANENT
+}
+
+type SelectSubscription {
+    id: ID!
+    """The active loyaltyProgram of a customer"""
+    loyaltyProgram: LoyaltyProgram
+}
+
+"""
+Canonical parameters for the home page, for example: { scheme: "https" host: "www.bol.com" } }) The canonical parameters are used to build up the canonical and hreflangTags
+"""
+input SeoCanonicalParameters {
+    scheme: String!
+    host: String!
+}
+
+"""
+Hreflang tags must be rendered as link with rel="alternate" and attributes hreflang and href from the HreflangTag object.
+"""
+type SeoHreflangTag {
+    """
+    Region of the page, to be placed in the hreflang attribute of the alternate link
+    """
+    hreflang: String!
+    """
+    Url of the page for the region, to be placed in the href attribute of the alternate link
+    """
+    href: String!
+}
+
+"""
+SEO metadata - a set of SEO-related tags intended for search engines and web crawlers
+"""
+type SeoMetadata {
+    """The meta title (title tag) indicating the topic of this page"""
+    metaTitle: String!
+    """The heading (H1) of this page"""
+    heading: String
+    """The meta description summarising this page's contents"""
+    metaDescription: String!
+    """
+    The robots tag indicating whether a page should be indexed and/or followed by a crawler
+    """
+    robots: [String!]!
+    """
+    The canonical URL pointing to the most representative page out of a set of similar pages
+    """
+    canonicalUrl: String
+    """
+    The hreflang tags indicating all the language and region variants of this page
+    """
+    hreflangTags: [SeoHreflangTag!]!
+}
+
+type SeoMetadataPages {
+    """SEO metadata for the Home page"""
+    homepage(canonicalParameters: SeoCanonicalParameters!): SeoMetadata!
+}
+
+"""A shop the look category."""
+type ShopTheLookCategory {
+    """The unique ID for this Category."""
+    id: ID!
+    """The title for the Category."""
+    title: String!
+    """An image URL for the Category."""
+    imageUrl: String
+    """A list of Sub-Categories for this Category."""
+    children: [ShopTheLookCategory!]!
+    """The parent category."""
+    parent: ShopTheLookCategory
+    """"""
+    url: String
+}
+
+"""Contains data needed to render a storefront page."""
+type StorefrontPage {
+    """Display title of the page"""
+    title: String!
+    """Optionally, id of a shopping category this page is related to."""
+    categoryId: Int
+    """Optionally, circle hero to display on top of the page."""
+    circleHero: CircleHero
+    """
+    Contains an ordered list of CMS components which need to be rendered in the middle slot of the page.
+    """
+    middleSlot: [CmsComponent]
+    """Contains HTML content of the SEO text snippet."""
+    seoSnippetHtml: String
+    """SEO metadata for this storefront page."""
+    seoMetadata: CmsSeoMetadata!
+}
+
+"""A strikethrough price for an offer."""
+type StrikethroughPrice {
+    """The strikethrough price."""
+    price: Money! @deprecated(reason: "Use the `Offer.fromPrice` instead")
+    """Type of the strikethrough price: LIST | NORMAL"""
+    type: StrikethroughPriceType! @deprecated(reason: "Use the `Offer.fromPriceType` instead")
+}
+
+"""Type of a strikethrough price."""
+enum StrikethroughPriceType {
+    """List price."""
+    LIST @deprecated(reason: "Use the `FromPriceType.LIST` instead.")
+    """Normal price."""
+    NORMAL @deprecated(reason: "Use the `FromPriceType.NORMAL` instead.")
+}
+
+"""
+A text item is the representation of a key and the respective text it represents.
+"""
+type TextItem {
+    """The key."""
+    key: String!
+    """It's value."""
+    text: String!
+}
+
+"""A text resource is a group of texts in a certain language."""
+type TextResource {
+    """The language."""
+    language: String!
+    """The name of this particular resource."""
+    name: String!
+    """The text items in this text resource."""
+    textItems: [TextItem!]!
+}
+
+"""Upcoming flash deal info"""
+type UpcomingFlashDealInfo {
+    """Flash deal's title"""
+    title: String!
+    """Campaign id"""
+    campaignId: String!
+    """Flash deal's start date"""
+    startDateTime: String!
+    """Flash deal's end date"""
+    endDateTime: String!
+}
+
+"""Result of saving/updating Data Sharing consent"""
+union UpdateDataSharingConsentResult = UpdatedDataSharingConsentResult
+
+"""Result of saving/updating Data Usage consent"""
+union UpdateDataUsageConsentResult = UpdatedDataUsageConsentResult
+
+"""Result for successful modification of Data Sharing consent"""
+type UpdatedDataSharingConsentResult {
+    """Version of updated consent"""
+    version: Int
+    """
+    Data sharing preferences, can be null if user didn't provide consent for the version
+    """
+    preferences: DataSharingPreferences
+}
+
+"""Result for successful modification of Data Usage consent"""
+type UpdatedDataUsageConsentResult {
+    """Version of updated consent"""
+    version: Int
+    """
+    Data Usage preferences, can be null if user didn't provide consent for the version
+    """
+    preferences: DataUsagePreferences
+}
+
+"""Enumeration that specifies the possible urgency levels."""
+enum Urgency {
+    """Medium level"""
+    MEDIUM
+    """High level"""
+    HIGH
+}
+
+"""Represent a key url combination object"""
+type UrlItem {
+    """The key used to refer to the url"""
+    key: String!
+    """The textResourceKey used by the FE to retrieve the translation"""
+    textResourceKey: String!
+    """The url"""
+    url: String!
+}
+
+"""A reference to a page that can be based on an identifier or a type."""
+type Urls {
+    """The android app flyer url"""
+    androidAppsFlyerUrl: String!
+    """The iOS app flyer url"""
+    iosAppsFlyerUrl: String!
+    """The iOS app flyer url"""
+    iOSAppsFlyerUrl: String! @deprecated(reason: "Use iosAppsFlyerUrl instead.")
+    """The customer service page url requires a Customer Service Page type"""
+    customerServicePageUrl(id: CustomerServicePage!): String
+    """
+    The account page url accepts Account Page Type, the default value is ORDERS
+    """
+    accountPageUrl(id: AccountPage = ORDERS): String
+    """The seller contact form url"""
+    sellerContactFormUrl(sellingOfferId: String!): String!
+    """The customer service url"""
+    customerServiceUrl: String!
+    """The partner terms and conditions url"""
+    partnerTermsAndConditionsUrl: String!
+    """The order overview url"""
+    orderOverviewUrl: String!
+    """The commonly asked questions url"""
+    commonlyAskedQuestionsUrl: String!
+    """Url to login with your bol account"""
+    loginUrl: String!
+    """Url to register for a new account at bol"""
+    registerAccountUrl: String!
+    """Overview of wishlists"""
+    wishlistOverviewUrl: String!
+    """The Checkout url"""
+    checkout: String!
+    """Url to the page with info on our policy on cookies"""
+    cookiesPolicy: String!
+    """Url to the page with info on our policy on privacy"""
+    privacyPolicy: String!
+    """A 'hashmap' of urls used by the web FE to populate the footer"""
+    webFooterUrls: [UrlItem!]!
+}
+
+"""Attributes of a video file."""
+type VideoFile {
+    """Video url."""
+    url: String!
+    """Video title."""
+    title: String
+}
+
+"""A container for a set of products added by the user"""
+type Wishlist {
+    """ID of the wishlist"""
+    id: ID!
+    """The title of the wishlist (sometimes also called name)"""
+    title: String!
+    """Whether this wishlist can be shared with/seen by others"""
+    public: Boolean!
+    """A boolean to indicate if the given $productId is part of this wishlist"""
+    containsProduct(productId: ID!): Boolean!
+}
+
+type WishlistItem {
+    """Id of the product on the wishlist"""
+    productId: ID!
+}
+
+type WishlistMutations {
+    """
+    Create a wishlist and add the item to the wishlist Can only be used by non-anonymous users
+    """
+    moveItemToNewWishlist(input: MoveItemToNewWishlistInput!): MoveItemToNewWishlistResult!
+    """
+    Move an item from one wishlist to another Can only be used by non-anonymous users
+    """
+    moveItemToExistingWishlist(input: MoveItemToExistingWishlistInput!): MoveItemToExistingWishlistResult!
+    """Add an item to your last used wishlist"""
+    addItemToLastUsedWishlist(input: AddItemToLastUsedWishlistInput!): AddItemToLastUsedWishlistResult!
+    """Delete an item from the wishlist it was last added to"""
+    deleteItemFromLastAddedWishlist(input: DeleteItemFromLastAddedWishlistInput!): DeleteItemFromLastAddedWishlistResult!
+}
+
+"""
+Wrapper of an array of wishlist to workaround the fact that you cant have a array type in an union
+"""
+type WishlistOverview {
+    wishlists: [Wishlist!]!
+}
+
+enum WishlistSortOption {
+    """Ordered by mutation date most recent first"""
+    MUTATION_ASC
+    """Ordered by mutation date oldest first"""
+    MUTATION_DESC
+    """Ordered by creation date most recent first"""
+    CREATION_ASC
+    """Ordered by creation date most oldest first"""
+    CREATION_DESC
+    """
+    Ordered by wishlist title starting with first letters of the alphabet first
+    """
+    TITLE_ASC
+    """
+    Ordered by wishlist title starting with last letters of the alphabet first
+    """
+    TITLE_DESC
+}


### PR DESCRIPTION
- Change some counters to histogram to gain insights in time spend per protection
- Cleanup unused code
- Rename `fail_unknown_operations` to `reject_on_failure` for persisted operations to be consistent with other protection configuration naming
- Update documentation