### PR TITLE
feat(rename-repo): Rename repository to graphql-protect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-armor.yml
+protect.yml
 operations.json
 TODO.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ ARG BUILD_DATE
 ARG VERSION
 ARG REVISION
 
-LABEL org.opencontainers.image.title=go-graphql-armor \
+LABEL org.opencontainers.image.title=graphql-protect \
 	org.opencontainers.image.description="A dead-simple yet highly customizable security sidecar compatible with any HTTP GraphQL Server or Gateway." \
 	org.opencontainers.image.created=$BUILD_DATE \
 	org.opencontainers.image.authors=ldebruijn \
-	org.opencontainers.image.url=https://github.com/ldebruijn/go-graphql-armor \
-	org.opencontainers.image.documentation=https://github.com/ldebruijn/go-graphql-armor \
-	org.opencontainers.image.source=https://github.com/ldebruijn/go-graphql-armor \
+	org.opencontainers.image.url=https://github.com/ldebruijn/graphql-protect \
+	org.opencontainers.image.documentation=https://github.com/ldebruijn/graphql-protect \
+	org.opencontainers.image.source=https://github.com/ldebruijn/graphql-protect \
 	org.opencontainers.image.version=$VERSION \
 	org.opencontainers.image.revision=$REVISION \
 	org.opencontainers.image.licenses=MIT \
@@ -26,9 +26,9 @@ USER go
 
 WORKDIR /app
 
-COPY main /app/go-graphql-armor
+COPY main /app/graphql-protect
 
 EXPOSE 8080
 
-ENTRYPOINT ["/app/go-graphql-armor"]
+ENTRYPOINT ["/app/graphql-protect"]
 CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Go GraphQL Armor 🛡️
+# GraphQL Protect 🛡️
 
-Go GraphQL Armor is dead-simple yet highly customizable security sidecar compatible with any HTTP GraphQL Server or Gateway.
+GraphQL Protect is dead-simple yet highly customizable security sidecar compatible with any HTTP GraphQL Server or Gateway.
 
-![Go GraphQL Armor Banner](docs/assets/banner.jpeg?raw=true)
+![GraphQL Protect Banner](docs/assets/banner.jpeg?raw=true)
 
-[![Go](https://github.com/ldebruijn/go-graphql-armor/actions/workflows/go.yml/badge.svg)](https://github.com/ldebruijn/go-graphql-armor/actions/workflows/go.yml)
+[![Go](https://github.com/ldebruijn/graphql-protect/actions/workflows/go.yml/badge.svg)](https://github.com/ldebruijn/graphql-protect/actions/workflows/go.yml)
 
-_This is repository inspired by the great work of the similarly named Javascript [GraphQL Armor](https://github.com/Escape-Technologies/graphql-armor) middleware._
+_This is repository inspired by the great work of the similarly named Javascript [GraphQL Protect](https://github.com/Escape-Technologies/graphql-armor) middleware._
 
 <!-- TOC -->
 
@@ -28,15 +28,15 @@ Curious why you need these features? Check out this [Excellent talk on GraphQL s
 
 ## As Container
 ```shell
-docker pull ghcr.io/ldebruijn/go-graphql-armor:latest
-docker run -p 8080:8080 -v $(pwd)/armor.yml:/app/armor.yml ghcr.io/ldebruijn/go-graphql-armor:latest
+docker pull ghcr.io/ldebruijn/graphql-protect:latest
+docker run -p 8080:8080 -v $(pwd)/protect.yml:/app/protect.yml ghcr.io/ldebruijn/graphql-protect:latest
 ```
 Make sure to portforward the right ports for your supplied configuration
 
 ## Source code
 
 ```shell
-git clone git@github.com:ldebruijn/go-graphql-armor.git
+git clone git@github.com:ldebruijn/graphql-protect.git
 ```
 
 Build & Test
@@ -56,20 +56,20 @@ Run Container
 
 ## Configuration
 
-We recommend configuring the binary using a yaml file, place a file called `armor.yml` in the same directory as you're running the binary.
+We recommend configuring the binary using a yaml file, place a file called `protect.yml` in the same directory as you're running the binary.
 
 For all the configuration options check out the [Configuration Documentation](docs/configuration.md)
 
-Alternatively go-graphql-armor can be configured using environment variables or command line arguments.
+Alternatively graphql-protect can be configured using environment variables or command line arguments.
 
 ## Contributing
 
-Ensure you have read the [Contributing Guide](https://github.com/ldebruijn/go-graphql-armor/blob/main/CONTRIBUTING.md) before contributing.
+Ensure you have read the [Contributing Guide](https://github.com/ldebruijn/graphql-protect/blob/main/CONTRIBUTING.md) before contributing.
 
 To set up your project, make sure you run the `make dev.setup` script.
 
 ```bash
-git clone git@github.com:ldebruijn/go-graphql-armor.git
-cd go-graphql-armor
+git clone git@github.com:ldebruijn/graphql-protect.git
+cd graphql-protect
 make dev.setup
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,19 +7,19 @@ import (
 	"flag"
 	"fmt"
 	"github.com/ardanlabs/conf/v3"
-	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/aliases"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/batch"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/enforce_post"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/max_depth"
-	middleware2 "github.com/ldebruijn/go-graphql-armor/internal/business/middleware"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/persisted_operations"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/proxy"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/readiness"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/schema"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/tokens"
+	"github.com/ldebruijn/graphql-protect/internal/app/config"
+	"github.com/ldebruijn/graphql-protect/internal/business/aliases"
+	"github.com/ldebruijn/graphql-protect/internal/business/batch"
+	"github.com/ldebruijn/graphql-protect/internal/business/block_field_suggestions"
+	"github.com/ldebruijn/graphql-protect/internal/business/enforce_post"
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/max_depth"
+	middleware2 "github.com/ldebruijn/graphql-protect/internal/business/middleware"
+	"github.com/ldebruijn/graphql-protect/internal/business/persisted_operations"
+	"github.com/ldebruijn/graphql-protect/internal/business/proxy"
+	"github.com/ldebruijn/graphql-protect/internal/business/readiness"
+	"github.com/ldebruijn/graphql-protect/internal/business/schema"
+	"github.com/ldebruijn/graphql-protect/internal/business/tokens"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -43,7 +43,7 @@ var (
 	configPath = ""
 
 	httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "go_graphql_armor",
+		Namespace: "graphql_protect",
 		Subsystem: "http",
 		Name:      "duration",
 		Help:      "HTTP duration",
@@ -52,7 +52,7 @@ var (
 	)
 
 	appInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "go_graphql_armor",
+		Namespace: "graphql_protect",
 		Subsystem: "app",
 		Name:      "info",
 		Help:      "Application information",
@@ -67,7 +67,7 @@ func init() {
 }
 
 func main() {
-	flag.StringVar(&configPath, "f", "./armor.yml", "Defines the path at which the configuration file can be found")
+	flag.StringVar(&configPath, "f", "./protect.yml", "Defines the path at which the configuration file can be found")
 	flag.Parse()
 
 	log := slog.Default()
@@ -147,7 +147,7 @@ func run(log *slog.Logger, cfg *config.Config, shutdown chan os.Signal) error { 
 	serverErrors := make(chan error, 1)
 
 	go func() {
-		log.Info("startup", "status", "go-graphql-armor started", "host", api.Addr)
+		log.Info("startup", "status", "graphql-protect started", "host", api.Addr)
 
 		serverErrors <- api.ListenAndServe()
 	}()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/ldebruijn/go-graphql-armor/internal/app/config"
+	"github.com/ldebruijn/graphql-protect/internal/app/config"
 	"github.com/stretchr/testify/assert"
 	"io"
 	log2 "log"

--- a/docs/block_field_suggestions.md
+++ b/docs/block_field_suggestions.md
@@ -8,7 +8,7 @@ Disabling field suggestions prevent the discovery of your GraphQL schema even wh
 
 ## Configuration
 
-You can configure `go-graphql-armor` to remove field suggestions from your API.
+You can configure `graphql-protect` to remove field suggestions from your API.
 
 ```yaml
 block_field_suggestions:
@@ -30,7 +30,7 @@ We scan each `errors[].message` field in the responses and replace the message w
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_block_field_suggestions_results{result}
+graphql_protect_block_field_suggestions_results{result}
 ```
 
 | `result`   | Description                                                         |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,12 @@
 # Configuration
 
-go-graphql-armor can be configured in various ways, though we recommend configuring it via a `armor.yml`. file
+graphql-protect can be configured in various ways, though we recommend configuring it via a `protect.yml`. file
 
 <!-- TOC -->
 
-# armor.yml
+# protect.yml
 
-The best way to configure `go-graphql-armor` is by specifying a `armor.yml` in the same directory as you're running the binary.
+The best way to configure `graphql-protect` is by specifying a `protect.yml` in the same directory as you're running the binary.
 
 The following outlines the structure of the yaml
 
@@ -36,7 +36,7 @@ schema:
     # The interval in which the schema file should be reloaded
     interval: 5m
     
-# Configures whether we obfuscate graphql-armor validation errors such as max_aliases/max_tokens
+# Configures whether we obfuscate graphql-protect validation errors such as max_aliases/max_tokens
 # Recommended to set it to 'true' for public environments
 obfuscate_validation_errors: false    
     
@@ -45,7 +45,7 @@ persisted_operations:
   enabled: true
   # Fail unknown operations, disable this feature to allow unknown operations to reach your GraphQL API
   reject_on_failure: true
-  # Store is the location on local disk where go-graphql-armor can find the persisted operations, it loads any `*.json` files on disk
+  # Store is the location on local disk where graphql-protect can find the persisted operations, it loads any `*.json` files on disk
   store: "./store"
   reload:
     enabled: true
@@ -102,7 +102,7 @@ For a more in-depth view of each option visit the accompanying documentation pag
 
 ## Environment Variables
 
-If so desired `go-graphql-armor` _can_ be configured using environment variables. write out the full configuration path for each value.
+If so desired `graphql-protect` _can_ be configured using environment variables. write out the full configuration path for each value.
 
 For example:
 
@@ -114,12 +114,12 @@ PERSISTED_OPERATIONS_STORE_GCP_BUCKET: gs://my-bucket
 
 ## Command line arguments
 
-Usage: go-graphql-armor [options] [arguments]
+Usage: graphql-protect [options] [arguments]
 
 Examples:
 
 ```bash
-go-graphql-armor \
+graphql-protect \
     --persisted-operations-enabled=true \
     --web-path=/graphql \
     --persisted-operations-store-gcp-bucket=gs://my-bucket
@@ -127,4 +127,4 @@ go-graphql-armor \
 
 ## Which configuration is applied?
 
-During startup `go-graphql-armor` will output its applied configuration. It will do this in command line argument format, though it will apply and output configuration from any of these sources.
+During startup `graphql-protect` will output its applied configuration. It will do this in command line argument format, though it will apply and output configuration from any of these sources.

--- a/docs/enforce_post.md
+++ b/docs/enforce_post.md
@@ -2,7 +2,7 @@
 
 A rule that enforces the use of HTTP POST method when sending operations to the upstream GraphQL API.
 
-The rule will block requests with non-POST HTTP methods **only** if the requests contain GraphQL operations. If no operation is found it will still forward the request to the upstream. This is useful for accessing GraphiQL for example through Go GraphQL Armor.
+The rule will block requests with non-POST HTTP methods **only** if the requests contain GraphQL operations. If no operation is found it will still forward the request to the upstream. This is useful for accessing GraphiQL for example through GraphQL Protect.
 
 
 <!-- TOC -->
@@ -20,7 +20,7 @@ enforce_post:
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_enforce_post_count{}
+graphql_protect_enforce_post_count{}
 ```
 
 No metrics are produced when the rule is disabled or never encounters operations through a non-POST request.

--- a/docs/max_aliases.md
+++ b/docs/max_aliases.md
@@ -9,7 +9,7 @@ Or even worse, uploading a 1 MB image with 1000 aliases in 1 request using the s
 
 ## Configuration
 
-You can configure `go-graphql-armor` to limit the maximum number of aliases allowed on an operation.
+You can configure `graphql-protect` to limit the maximum number of aliases allowed on an operation.
 
 ```yaml
 max_aliases:
@@ -26,7 +26,7 @@ max_aliases:
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_max_aliases_results{result}
+graphql_protect_max_aliases_results{result}
 ```
 
 

--- a/docs/max_batch.md
+++ b/docs/max_batch.md
@@ -7,7 +7,7 @@ This can be useful to prevent DDoS attacks, Heap Overflows or Server overload.
 
 ## Configuration
 
-You can configure `go-graphql-armor` to limit the maximum number of operations allowed inside a batch request.
+You can configure `graphql-protect` to limit the maximum number of operations allowed inside a batch request.
 
 ```yaml
 max_batch:
@@ -24,7 +24,7 @@ max_batch:
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_max_batch_results{result}
+graphql_protect_max_batch_results{result}
 ```
 
 

--- a/docs/max_depth.md
+++ b/docs/max_depth.md
@@ -6,7 +6,7 @@ Restricting the maximum depth of operations that are allowed within a single ope
 
 ## Configuration
 
-You can configure `go-graphql-armor` to limit the maximum depth on an operation.
+You can configure `graphql-protect` to limit the maximum depth on an operation.
 
 ```yaml
 max_depth:
@@ -23,7 +23,7 @@ max_depth:
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_max_depth_results{result}
+graphql_protect_max_depth_results{result}
 ```
 
 

--- a/docs/max_tokens.md
+++ b/docs/max_tokens.md
@@ -7,7 +7,7 @@ This can be useful to prevent DDoS attacks, Heap Overflows or Server overload.
 
 ## Configuration
 
-You can configure `go-graphql-armor` to limit the maximum number of tokens allowed on an operation.
+You can configure `graphql-protect` to limit the maximum number of tokens allowed on an operation.
 
 ```yaml
 max_tokens:
@@ -24,7 +24,7 @@ max_tokens:
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_max_tokens_results{result}
+graphql_protect_max_tokens_results{result}
 ```
 
 

--- a/docs/persisted_operations.md
+++ b/docs/persisted_operations.md
@@ -10,7 +10,7 @@ We recommend that all GraphQL APIs that only intend a specific/known set of clie
 
 ## Configuration
 
-You can configure `go-graphql-armor` to enable Persisted Operations.
+You can configure `graphql-protect` to enable Persisted Operations.
 
 ```yaml
 # ...
@@ -20,7 +20,7 @@ persisted_operations:
   enabled: "true"
   # Fail unknown operations, disable this feature to allow unknown operations to reach your GraphQL API
   reject_on_failure: "true"
-  # Store is the location on local disk where go-graphql-armor can find the persisted operations, it loads any `*.json` files on disk
+  # Store is the location on local disk where graphql-protect can find the persisted operations, it loads any `*.json` files on disk
   store: "./store"
   reload:
     enabled: "true"
@@ -38,7 +38,7 @@ persisted_operations:
 
 ## How it works
 
-`go-graphql-armor` looks at the `store` location on local disk to find any `*.json` files it can parse for persisted operations. 
+`graphql-protect` looks at the `store` location on local disk to find any `*.json` files it can parse for persisted operations. 
 
 It can be configured to look at this directory and reload based on the files on local disk.
 
@@ -46,7 +46,7 @@ Additionally, it can be configured to fetch operations from a remote location on
 
 ## Parsing Structure
 
-To be able to parse Persisted Operations go-graphql-armor expects a `key-value` structure for `hash-operation` in the files.
+To be able to parse Persisted Operations graphql-protect expects a `key-value` structure for `hash-operation` in the files.
 
 `any-file.json`
 ```json
@@ -85,7 +85,7 @@ In order to utilize this feature you need to generate the persisted operations t
 This rule produces metrics to help you gain insights into the behavior of the rule.
 
 ```
-go_graphql_armor_persisted_operations_results{state, result}
+graphql_protect_persisted_operations_results{state, result}
 ```
 
 | `state`  | Description                                                                                                                                                   |
@@ -101,7 +101,7 @@ go_graphql_armor_persisted_operations_results{state, result}
 | `rejected` | The rule rejected the request |
 
 ```
-go_graphql_armor_persisted_operations_reload{system}
+graphql_protect_persisted_operations_reload{system}
 ```
 
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Schema
 
-`go-graphql-armor` needs to know your schema in order to perform its validations. 
+`graphql-protect` needs to know your schema in order to perform its validations. 
 
 <!-- TOC -->
 
@@ -25,7 +25,7 @@ schema:
 ## Metrics
 
 ```
-go_graphql_armor_schema_reload{state}
+graphql_protect_schema_reload{state}
 ```
 
 | `state`   | Description                                                 |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ldebruijn/go-graphql-armor
+module github.com/ldebruijn/graphql-protect
 
 go 1.21.1
 

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"github.com/ardanlabs/conf/v3"
 	"github.com/ardanlabs/conf/v3/yaml"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/aliases"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/batch"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/enforce_post"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/max_depth"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/persisted_operations"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/proxy"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/schema"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/tokens"
+	"github.com/ldebruijn/graphql-protect/internal/business/aliases"
+	"github.com/ldebruijn/graphql-protect/internal/business/batch"
+	"github.com/ldebruijn/graphql-protect/internal/business/block_field_suggestions"
+	"github.com/ldebruijn/graphql-protect/internal/business/enforce_post"
+	"github.com/ldebruijn/graphql-protect/internal/business/max_depth"
+	"github.com/ldebruijn/graphql-protect/internal/business/persisted_operations"
+	"github.com/ldebruijn/graphql-protect/internal/business/proxy"
+	"github.com/ldebruijn/graphql-protect/internal/business/schema"
+	"github.com/ldebruijn/graphql-protect/internal/business/tokens"
 	"os"
 	"time"
 )
@@ -44,7 +44,7 @@ type Config struct {
 func NewConfig(configPath string) (*Config, error) {
 	cfg := Config{}
 
-	help, err := conf.Parse("go-graphql-armor", &cfg)
+	help, err := conf.Parse("graphql-protect", &cfg)
 	if err != nil {
 		if errors.Is(err, conf.ErrHelpWanted) {
 			fmt.Println(help)

--- a/internal/business/aliases/aliases.go
+++ b/internal/business/aliases/aliases.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	resultHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "go_graphql_armor",
+		Namespace: "graphql_protect",
 		Subsystem: "max_aliases",
 		Name:      "results",
 		Help:      "The results of the max aliases rule",

--- a/internal/business/batch/batch.go
+++ b/internal/business/batch/batch.go
@@ -3,13 +3,13 @@ package batch
 import (
 	"errors"
 	"fmt"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
 	resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "go_graphql_armor",
+		Namespace: "graphql_protect",
 		Subsystem: "max_batch",
 		Name:      "results",
 		Help:      "The results of the max batch rule",

--- a/internal/business/batch/batch_test.go
+++ b/internal/business/batch/batch_test.go
@@ -1,7 +1,7 @@
 package batch
 
 import (
-	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/internal/business/block_field_suggestions/block_field_suggestions.go
+++ b/internal/business/block_field_suggestions/block_field_suggestions.go
@@ -6,7 +6,7 @@ import (
 )
 
 var resultCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "go_graphql_armor",
+	Namespace: "graphql_protect",
 	Subsystem: "block_field_suggestions",
 	Name:      "results",
 	Help:      "The results of the block field suggestions rule",

--- a/internal/business/enforce_post/enforce_post.go
+++ b/internal/business/enforce_post/enforce_post.go
@@ -6,7 +6,7 @@ import (
 )
 
 var methodCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "go_graphql_armor",
+	Namespace: "graphql_protect",
 	Subsystem: "enforce_post",
 	Name:      "count",
 	Help:      "Amount of times the enforce POST rule was triggered and blocked a request",

--- a/internal/business/max_depth/max_depth.go
+++ b/internal/business/max_depth/max_depth.go
@@ -9,7 +9,7 @@ import (
 )
 
 var resultHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "go_graphql_armor",
+	Namespace: "graphql_protect",
 	Subsystem: "max_depth",
 	Name:      "results",
 	Help:      "The results of the max_depth rule",

--- a/internal/business/middleware/recover.go
+++ b/internal/business/middleware/recover.go
@@ -8,7 +8,7 @@ import (
 )
 
 var recoverCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "go_graphql_armor",
+	Namespace: "graphql_protect",
 	Subsystem: "recover",
 	Name:      "count",
 	Help:      "Amount of times the middleware recovered a panic",

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"io"
@@ -20,7 +20,7 @@ import (
 
 var (
 	persistedOpsHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "go_graphql_armor",
+		Namespace: "graphql_protect",
 		Subsystem: "persisted_operations",
 		Name:      "counter",
 		Help:      "The results of the persisted operations rule",
@@ -28,7 +28,7 @@ var (
 		[]string{"state", "result"},
 	)
 	reloadCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   "go_graphql_armor",
+		Namespace:   "graphql_protect",
 		Subsystem:   "persisted_operations",
 		Name:        "reload",
 		Help:        "Counter tracking reloading behavior and results",

--- a/internal/business/persisted_operations/persisted_operations_test.go
+++ b/internal/business/persisted_operations/persisted_operations_test.go
@@ -3,7 +3,7 @@ package persisted_operations // nolint:revive
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"log/slog"

--- a/internal/business/proxy/proxy.go
+++ b/internal/business/proxy/proxy.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
+	"github.com/ldebruijn/graphql-protect/internal/business/block_field_suggestions"
 	"io"
 	"net"
 	"net/http"

--- a/internal/business/proxy/proxy_test.go
+++ b/internal/business/proxy/proxy_test.go
@@ -1,7 +1,7 @@
 package proxy
 
 import (
-	"github.com/ldebruijn/go-graphql-armor/internal/business/block_field_suggestions"
+	"github.com/ldebruijn/graphql-protect/internal/business/block_field_suggestions"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"

--- a/internal/business/schema/schema.go
+++ b/internal/business/schema/schema.go
@@ -11,7 +11,7 @@ import (
 )
 
 var reloadGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-	Namespace:   "go_graphql_armor",
+	Namespace:   "graphql_protect",
 	Subsystem:   "schema",
 	Name:        "reload",
 	Help:        "Gauge tracking reloading behavior",

--- a/internal/business/tokens/tokens.go
+++ b/internal/business/tokens/tokens.go
@@ -9,7 +9,7 @@ import (
 )
 
 var resultHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "go_graphql_armor",
+	Namespace: "graphql_protect",
 	Subsystem: "max_tokens",
 	Name:      "results",
 	Help:      "The results of the max tokens rule",

--- a/makefile
+++ b/makefile
@@ -27,8 +27,8 @@ lint:
 
 .PHONY: build_container
 build_container: build
-	docker build . -t go-graphql-armor --build-arg BUILD_DATE=$(BUILD_DATE) --build-arg VERSION=$(VERSION) --build-arg REVISION=$(SHORT_HASH)
+	docker build . -t graphql-protect --build-arg BUILD_DATE=$(BUILD_DATE) --build-arg VERSION=$(VERSION) --build-arg REVISION=$(SHORT_HASH)
 
 .PHONY: run_container
 run_container: build_container
-	go run -d -p 8080:8080 go-graphql-armor
+	go run -d -p 8080:8080 graphql-protect


### PR DESCRIPTION
Rename the repository from go-graphql-armor to graphql-protect.

Main reason for renaming are:
- We have a lot of similarity with graphql-armor, which has a different purpose and feature set
- Having `go-` in the name might confuse potential users about the purpose of graphql-protect, thinking it only applies for golang applications
- graphql-shield was another option for the name, but is already taken by another solution.

After merging the repository URL will also be updated.